### PR TITLE
Fix diff smoke tests to handle pnpm warnings

### DIFF
--- a/.changeset/relax-diff-smoke-json-check.md
+++ b/.changeset/relax-diff-smoke-json-check.md
@@ -1,0 +1,6 @@
+---
+'@dtifx/diff': patch
+---
+
+Improve the diff CLI smoke test to tolerate pnpm warnings and whitespace-only formatting differences
+in its assertions.


### PR DESCRIPTION
## Summary
- relax CLI smoke test assertions so minor formatting changes do not fail the diff report checks
- strip any leading pnpm warnings from the quiet JSON output so parsing stays stable in CI

## Testing
- ./scripts/smoke-diff.sh
- ./scripts/smoke-build.sh
- ./scripts/smoke-audit.sh
- NX_NATIVE_LOGGING=false pnpm lint
- NX_NATIVE_LOGGING=false pnpm lint:markdown
- NX_NATIVE_LOGGING=false pnpm build
- CI=1 NX_NATIVE_LOGGING=false NX_DAEMON=false pnpm test
- pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68f3ab3e8ff88328a3b1bcedf2a5afda