### PR TITLE
chore: add changeset for first public release

### DIFF
--- a/.changeset/first-public-release.md
+++ b/.changeset/first-public-release.md
@@ -1,0 +1,18 @@
+---
+'@dtifx/core': major
+'@dtifx/cli': major
+'@dtifx/build': major
+'@dtifx/audit': major
+'@dtifx/diff': major
+---
+
+Initial public release of the DTIFx Toolkit.
+
+- `@dtifx/core` – Shared runtime with structured logging, telemetry primitives, and policy
+  utilities.
+- `@dtifx/cli` – Unified command line that wires audit, build, and diff workflows with consistent
+  UX.
+- `@dtifx/build` – DTIF-aware build orchestrator for transforms, caching, and formatter pipelines.
+- `@dtifx/audit` – Governance engine for evaluating policies and reporting actionable compliance
+  signals.
+- `@dtifx/diff` – Token diff engine with rich reporters, impact analysis, and CI-ready gates.


### PR DESCRIPTION
## Summary
- add a changeset describing the DTIFx Toolkit's first public release
- capture release notes for @dtifx/core, @dtifx/cli, @dtifx/build, @dtifx/audit, and @dtifx/diff

## Testing
- pnpm lint
- pnpm lint:markdown
- NX_STREAM_OUTPUT=1 pnpm build
- VITEST_CI=1 NX_STREAM_OUTPUT=1 pnpm test
- NX_STREAM_OUTPUT=1 pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68f3cc9362848328aeaf13cebfbac212