### PR TITLE
ci: remove docs manual trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,24 @@
 name: Deploy documentation
 
 on:
-  release:
-    types: [published]
-  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '*.md'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '*.md'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/docs.yml'
 
 permissions:
   contents: read
@@ -37,6 +52,9 @@ jobs:
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
 
+      - name: Format check
+        run: pnpm format:check
+
       - name: Build VitePress site
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -48,6 +66,7 @@ jobs:
           path: docs/.vitepress/dist
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     needs: build
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
- trigger the documentation workflow on pushes to main and docs-related pull requests
- add a format check before the VitePress build and gate deployments to the main branch
- remove the manual workflow_dispatch trigger so the docs pipeline only runs automatically

## Testing
- pnpm lint
- pnpm lint:markdown
- pnpm build
- pnpm test
- pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68f3cd3f2f9c8328a3c4b18c6d43bc57