### PR TITLE
chore(ci): align changesets commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: 'pnpm run release'
+          commit: 'chore: release packages'
           title: 'chore: release packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary
- configure the release workflow to have the changesets action use a conventional commit message so release PRs satisfy commitlint

## Testing
- CI=1 pnpm lint
- pnpm lint:markdown
- CI=1 pnpm build
- CI=1 pnpm test
- CI=1 pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68f3da9c04308328b4758c14b9ef8099