### PR TITLE
Fix Vitest config to include package tests and stabilize CLI integration

### DIFF
--- a/.changeset/enable-cli-test-infra.md
+++ b/.changeset/enable-cli-test-infra.md
@@ -1,0 +1,5 @@
+---
+'@dtifx/cli': patch
+---
+
+enable formatter plugin integration test to run against workspace dependencies

--- a/vitest.config.base.ts
+++ b/vitest.config.base.ts
@@ -1,5 +1,10 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from 'vitest/config';
 import tsconfigPaths from 'vite-tsconfig-paths';
+
+const repoRoot = fileURLToPath(new URL('.', import.meta.url));
 
 export default defineConfig({
   plugins: [tsconfigPaths()],
@@ -7,12 +12,16 @@ export default defineConfig({
     passWithNoTests: true,
     environment: 'node',
     globals: true,
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    include: ['{src,tests}/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['**/dist/**', '**/coverage/**'],
     clearMocks: true,
     restoreMocks: true,
     unstubEnvs: true,
     unstubGlobals: true,
+    env: {
+      PNPM_WORKSPACE_DIR: repoRoot,
+      NODE_PATH: path.join(repoRoot, 'node_modules'),
+    },
     coverage: {
       enabled: true,
       provider: 'v8',


### PR DESCRIPTION
## Summary
- update the shared Vitest configuration to pick up package-level test suites and expose workspace env vars so child processes can locate the monorepo
- adjust the CLI formatter plugin integration test to create a throwaway package with node_modules symlinked back to the repo and run the CLI from the package root
- record the change with a changeset entry for the CLI package

## Testing
- CI=1 pnpm lint
- CI=1 pnpm lint:markdown
- CI=1 pnpm build
- CI=1 pnpm test
- CI=1 pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68f3ddd23798832893f6d43749f6d0b0