### PR TITLE
docs: disable markdownlint duplicate changelog headings

### DIFF
--- a/packages/audit/CHANGELOG.md
+++ b/packages/audit/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @dtifx/audit
 
+<!-- markdownlint-disable MD024 -->
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/build/CHANGELOG.md
+++ b/packages/build/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @dtifx/build
 
+<!-- markdownlint-disable MD024 -->
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @dtifx/cli
 
+<!-- markdownlint-disable MD024 -->
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/diff/CHANGELOG.md
+++ b/packages/diff/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @dtifx/diff
 
+<!-- markdownlint-disable MD024 -->
+
 ## 1.0.0
 
 ### Major Changes


### PR DESCRIPTION
## Summary
- add inline markdownlint suppressions to changelog files that repeat the "Patch Changes" heading

## Testing
- pnpm lint
- pnpm lint:markdown
- pnpm build
- pnpm test
- pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68f42c60d2e083288bd8b03693652546