### PR TITLE
docs: surface minimal stack example in examples navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,11 @@ API reference material. Key entry points include:
 - [Diff workflow](docs/guides/diff-workflow.md)
 - [Audit governance](docs/guides/audit-governance.md)
 - [CLI reference](docs/reference/cli.md)
-- [Minimal stack example](https://github.com/bylapidist/dtifx-example) pairs the toolkit with
-  design-lint, publishes committed build/diff/audit artefacts, and exposes the core scripts you can
-  mirror in your own repositories (`npm run verify`, `npm run dtif:validate`, `npm run dtif:build`,
-  `npm run dtif:diff`, `npm run dtif:audit`, and `npm run design-lint`).
+- [Minimal stack example](docs/examples/minimal-stack.md) pairs the toolkit with design-lint,
+  publishes committed build/diff/audit artefacts, and exposes the core scripts you can mirror in
+  your own repositories (`npm run verify`, `npm run dtif:validate`, `npm run dtif:build`,
+  `npm run dtif:diff`, `npm run dtif:audit`, and `npm run design-lint`). Review the companion
+  [repository](https://github.com/bylapidist/dtifx-example) to inspect the full project wiring.
 
 Preview the site locally with `pnpm docs:dev` and publish via the automated
 [documentation workflow](https://github.com/bylapidist/dtifx/actions/workflows/docs.yml).

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -51,7 +51,14 @@ export default defineConfig({
       {
         text: 'Support',
         items: [
-          { text: 'Examples', link: '/examples/automation' },
+          {
+            text: 'Examples',
+            items: [
+              { text: 'Automation script', link: '/examples/automation' },
+              { text: 'Build preset config', link: '/examples/build-presets' },
+              { text: 'Minimal stack', link: '/examples/minimal-stack' },
+            ],
+          },
           { text: 'Troubleshooting', link: '/troubleshooting/' },
         ],
       },
@@ -164,6 +171,7 @@ export default defineConfig({
           items: [
             { text: 'Automation script', link: '/examples/automation' },
             { text: 'Build preset config', link: '/examples/build-presets' },
+            { text: 'Minimal stack', link: '/examples/minimal-stack' },
           ],
         },
       ],

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,9 +18,6 @@ hero:
     - theme: alt
       text: Explore package hubs
       link: /core/
-    - theme: alt
-      text: Try the minimal stack example
-      link: /examples/minimal-stack
 features:
   - icon:
       src: /logos/dtifx-core.svg


### PR DESCRIPTION
## Summary
- remove the minimal stack hero action from the home page
- add the minimal stack entry to the Support → Examples menu and sidebar
- point the repository README to the docs-hosted minimal stack example

## Testing
- pnpm lint
- pnpm lint:markdown
- pnpm build
- CI=1 pnpm test
- pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68f527c154f08328a07bc0d19cee69a7