### PR TITLE
fix: drop style dictionary sample stub

### DIFF
--- a/.changeset/add-dtifx-init-command.md
+++ b/.changeset/add-dtifx-init-command.md
@@ -1,0 +1,5 @@
+---
+'@dtifx/cli': minor
+---
+
+Add a `dtifx init` scaffolder with local templates, workspace validation, and documentation updates.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -23,6 +23,24 @@ corepack enable pnpm
 
 ## 2. Initialise the workspace
 
+### Scaffolding with `dtifx init`
+
+Generate a workspace with configuration, sample tokens, and downstream integration stubs:
+
+```bash
+pnpm dlx @dtifx/cli dtifx init my-design-system
+cd my-design-system
+```
+
+The command prompts for the package manager, whether to include sample data, and if Git should be
+initialised. Pass `--yes` and `--no-sample-data`/`--no-git` to skip the questions. The scaffolder
+prepares `dtifx.config.mjs`, installs dependencies, and wires common scripts in `package.json`. When
+you opt into the sample data you can skip to [exercise the workflows](#5-exercise-the-workflows).
+
+### Manual bootstrap
+
+Prefer to assemble the project by hand? Create a directory, add dependencies, and register scripts:
+
 ```bash
 mkdir dtifx-sample
 cd dtifx-sample

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,7 +45,8 @@
   },
   "files": [
     "dist",
-    "LICENSE"
+    "LICENSE",
+    "templates"
   ],
   "sideEffects": false,
   "dependencies": {

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -10,6 +10,7 @@ import {
   createCliKernel,
   createProcessCliIo,
   diffCommandModule,
+  initCommandModule,
 } from './index.js';
 
 const require = createRequire(import.meta.url);
@@ -59,14 +60,15 @@ const kernel = createCliKernel({
 kernel.register(diffCommandModule);
 kernel.register(buildCommandModule);
 kernel.register(auditCommandModule);
+kernel.register(initCommandModule);
 
 const exitCode = await kernel.run();
 
 if (process.argv.length <= 2) {
   const name = packageManifest.name ?? '@dtifx/cli';
   const message =
-    `${name} supports diff, build, and audit workflows. ` +
-    'Explore `dtifx diff --help`, `dtifx build --help`, or `dtifx audit --help` to get started.\n';
+    `${name} supports init, diff, build, and audit workflows. ` +
+    'Explore `dtifx init --help`, `dtifx diff --help`, `dtifx build --help`, or `dtifx audit --help` to get started.\n';
   io.writeOut(message);
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,7 @@ export type { CliIo } from './io/cli-io.js';
 export { diffCommandModule } from './tools/diff/diff-command-module.js';
 export { buildCommandModule } from './tools/build/build-command-module.js';
 export { auditCommandModule } from './tools/audit/audit-command-module.js';
+export { initCommandModule } from './tools/init/init-command-module.js';
 export { createDiffCliKernel, runDiffCli } from './tools/diff/run-diff-cli.js';
 export type { CompareCommandOptions } from './tools/diff/compare-options.js';
 export { createBuildCliKernel, runBuildCli } from './tools/build/run-build-cli.js';

--- a/packages/cli/src/tools/init/init-command-module.spec.ts
+++ b/packages/cli/src/tools/init/init-command-module.spec.ts
@@ -1,0 +1,123 @@
+import path from 'node:path';
+import process from 'node:process';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { questionMock, closeMock, writeMock, createInterfaceMock } = vi.hoisted(() => {
+  const question = vi.fn<(query: string) => Promise<string>>();
+  const close = vi.fn<[], void>();
+  const write = vi.fn<(text: string) => void>();
+  const createInterface = vi.fn(() => ({
+    question,
+    close,
+    write,
+  }));
+
+  return {
+    questionMock: question,
+    closeMock: close,
+    writeMock: write,
+    createInterfaceMock: createInterface,
+  };
+});
+
+vi.mock('node:readline/promises', () => {
+  return {
+    createInterface: createInterfaceMock,
+  };
+});
+
+vi.mock('./scaffold.js', () => {
+  return {
+    scaffoldWorkspace: vi.fn(async () => {}),
+  };
+});
+
+import { createCliKernel } from '../../kernel/cli-kernel.js';
+import { createMemoryCliIo } from '../../testing/memory-cli-io.js';
+import { initCommandModule } from './init-command-module.js';
+
+const loadScaffoldMock = async () => {
+  const module = (await import('./scaffold.js')) as {
+    scaffoldWorkspace: ReturnType<typeof vi.fn>;
+  };
+  return vi.mocked(module.scaffoldWorkspace);
+};
+
+describe('initCommandModule', () => {
+  beforeEach(async () => {
+    const scaffoldWorkspaceMock = await loadScaffoldMock();
+    scaffoldWorkspaceMock.mockReset();
+    questionMock?.mockReset();
+    closeMock?.mockReset();
+    writeMock?.mockReset();
+    createInterfaceMock?.mockReset();
+  });
+
+  it('prompts for metadata and scaffolds the workspace', async () => {
+    const scaffoldWorkspaceMock = await loadScaffoldMock();
+    const io = createMemoryCliIo();
+    const kernel = createCliKernel({ programName: 'dtifx', version: '0.0.0-test', io });
+
+    kernel.register(initCommandModule);
+
+    if (!questionMock || !closeMock) {
+      throw new Error('readline mocks not initialised');
+    }
+
+    questionMock.mockResolvedValueOnce('Design System');
+    questionMock.mockResolvedValueOnce('yarn');
+    questionMock.mockResolvedValueOnce('y');
+    questionMock.mockResolvedValueOnce('n');
+
+    await kernel.run(['node', 'dtifx', 'init']);
+
+    expect(scaffoldWorkspaceMock).toHaveBeenCalledTimes(1);
+    expect(closeMock).toHaveBeenCalledTimes(1);
+
+    const call = scaffoldWorkspaceMock.mock.calls[0]?.[0];
+    expect(call?.metadata).toMatchObject({
+      name: 'design-system',
+      displayName: 'Design System',
+      packageManager: 'yarn',
+      includeSampleData: true,
+      initializeGit: false,
+      destination: path.resolve(process.cwd(), 'design-system'),
+    });
+  });
+
+  it('accepts defaults when the yes flag is provided', async () => {
+    const scaffoldWorkspaceMock = await loadScaffoldMock();
+    const io = createMemoryCliIo();
+    const kernel = createCliKernel({ programName: 'dtifx', version: '0.0.0-test', io });
+
+    kernel.register(initCommandModule);
+
+    questionMock.mockReset();
+
+    const exitCode = await kernel.run([
+      'node',
+      'dtifx',
+      'init',
+      'workspace-demo',
+      '--yes',
+      '--package-manager',
+      'npm',
+      '--no-sample-data',
+      '--no-git',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(scaffoldWorkspaceMock).toHaveBeenCalledTimes(1);
+
+    const call = scaffoldWorkspaceMock.mock.calls[0]?.[0];
+    expect(call?.metadata).toMatchObject({
+      name: 'workspace-demo',
+      displayName: 'workspace-demo',
+      packageManager: 'npm',
+      includeSampleData: false,
+      initializeGit: false,
+      destination: path.resolve(process.cwd(), 'workspace-demo'),
+    });
+  });
+});

--- a/packages/cli/src/tools/init/init-command-module.ts
+++ b/packages/cli/src/tools/init/init-command-module.ts
@@ -1,0 +1,203 @@
+import path from 'node:path';
+import process from 'node:process';
+import { createInterface } from 'node:readline/promises';
+
+import type { Command } from 'commander';
+
+import type { CliCommandModule } from '../../kernel/types.js';
+import type { PackageManager } from './scaffold.js';
+import { scaffoldWorkspace } from './scaffold.js';
+
+interface InitCommandOptions {
+  readonly packageManager?: string;
+  readonly sampleData?: boolean;
+  readonly git?: boolean;
+  readonly yes?: boolean;
+}
+
+const packageManagers: readonly PackageManager[] = ['pnpm', 'npm', 'yarn', 'bun'];
+
+const isPackageManager = (value: string): value is PackageManager => {
+  return packageManagers.includes(value as PackageManager);
+};
+
+const sanitizeSegment = (segment: string): string => {
+  return segment
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9._~-]+/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '');
+};
+
+const sanitizePackageName = (name: string): string => {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    return 'dtifx-workspace';
+  }
+
+  if (trimmed.startsWith('@')) {
+    const [scope, pkg] = trimmed.slice(1).split('/');
+    const sanitizedScope = sanitizeSegment(scope ?? '');
+    const sanitizedPackage = sanitizeSegment(pkg ?? '');
+    if (sanitizedScope && sanitizedPackage) {
+      return `@${sanitizedScope}/${sanitizedPackage}`;
+    }
+    if (sanitizedScope) {
+      return `@${sanitizedScope}/${sanitizedPackage || 'dtifx-workspace'}`;
+    }
+  }
+
+  const sanitized = sanitizeSegment(trimmed);
+  return sanitized.length > 0 ? sanitized : 'dtifx-workspace';
+};
+
+const askQuestion = async (
+  prompt: string,
+  defaultValue: string,
+  readline: ReturnType<typeof createInterface>,
+): Promise<string> => {
+  const suffix = defaultValue.length > 0 ? ` (${defaultValue})` : '';
+  const answer = await readline.question(`${prompt}${suffix}: `);
+  const trimmed = answer.trim();
+  return trimmed.length > 0 ? trimmed : defaultValue;
+};
+
+const askPackageManager = async (
+  defaultValue: PackageManager,
+  readline: ReturnType<typeof createInterface>,
+): Promise<PackageManager> => {
+  const choices = packageManagers.join('/');
+  while (true) {
+    const answer = await readline.question(`Package manager [${choices}] (${defaultValue}): `);
+    const trimmed = answer.trim();
+    if (trimmed.length === 0) {
+      return defaultValue;
+    }
+
+    if (isPackageManager(trimmed.toLowerCase())) {
+      return trimmed.toLowerCase() as PackageManager;
+    }
+
+    readline.write(`Please choose one of: ${choices}.\n`);
+  }
+};
+
+const askBoolean = async (
+  prompt: string,
+  defaultValue: boolean,
+  readline: ReturnType<typeof createInterface>,
+): Promise<boolean> => {
+  const hint = defaultValue ? 'Y/n' : 'y/N';
+  while (true) {
+    const answer = await readline.question(`${prompt} [${hint}]: `);
+    const normalized = answer.trim().toLowerCase();
+    if (normalized.length === 0) {
+      return defaultValue;
+    }
+
+    if (normalized === 'y' || normalized === 'yes') {
+      return true;
+    }
+
+    if (normalized === 'n' || normalized === 'no') {
+      return false;
+    }
+
+    readline.write('Please answer yes or no.\n');
+  }
+};
+
+export const initCommandModule: CliCommandModule = {
+  id: 'init.scaffold',
+  register(program, context) {
+    const initCommand = program
+      .command('init')
+      .summary('Scaffold a DTIFx workspace with optional sample data.')
+      .description('Create a new DTIFx workspace with configuration, tokens, and integrations.');
+
+    initCommand
+      .argument('[project-name]', 'Directory for the new workspace.')
+      .option('-p, --package-manager <manager>', 'Package manager to use (pnpm, npm, yarn, bun).')
+      .option('--no-sample-data', 'Skip sample tokens and integration stubs.')
+      .option('--no-git', 'Skip git initialisation.')
+      .option('--yes', 'Accept defaults and skip interactive prompts.', false);
+
+    initCommand.action(
+      async (projectName: string | undefined, options: InitCommandOptions, command: Command) => {
+        const cwd = process.cwd();
+        const defaultDirectoryName = projectName
+          ? path.basename(path.resolve(cwd, projectName))
+          : 'dtifx-workspace';
+
+        const defaultDisplayName = defaultDirectoryName;
+        const defaultPackageManager: PackageManager =
+          options.packageManager && isPackageManager(options.packageManager)
+            ? (options.packageManager as PackageManager)
+            : 'pnpm';
+        const defaultSampleData = options.sampleData ?? true;
+        const defaultGit = options.git ?? true;
+
+        if (options.packageManager && !isPackageManager(options.packageManager)) {
+          command.error(`Unknown package manager: ${options.packageManager}`);
+          return;
+        }
+
+        if (options.yes) {
+          const displayName = defaultDisplayName;
+          const packageName = sanitizePackageName(displayName);
+          const destination = path.resolve(cwd, projectName ?? packageName);
+          await scaffoldWorkspace({
+            metadata: {
+              name: packageName,
+              displayName,
+              packageManager: defaultPackageManager,
+              includeSampleData: defaultSampleData,
+              initializeGit: defaultGit,
+              destination,
+            },
+            io: context.io,
+          });
+          return;
+        }
+
+        const readline = createInterface({
+          input: context.io.stdin,
+          output: context.io.stdout,
+          terminal: true,
+        });
+
+        try {
+          const displayName = await askQuestion('Workspace name', defaultDisplayName, readline);
+          const packageManager = await askPackageManager(defaultPackageManager, readline);
+          const includeSampleData = await askBoolean(
+            'Include sample data?',
+            defaultSampleData,
+            readline,
+          );
+          const initializeGit = await askBoolean(
+            'Initialise git repository?',
+            defaultGit,
+            readline,
+          );
+
+          const packageName = sanitizePackageName(displayName);
+          const destination = path.resolve(cwd, projectName ?? packageName);
+
+          await scaffoldWorkspace({
+            metadata: {
+              name: packageName,
+              displayName,
+              packageManager,
+              includeSampleData,
+              initializeGit,
+              destination,
+            },
+            io: context.io,
+          });
+        } finally {
+          readline.close();
+        }
+      },
+    );
+  },
+};

--- a/packages/cli/src/tools/init/scaffold.spec.ts
+++ b/packages/cli/src/tools/init/scaffold.spec.ts
@@ -1,0 +1,118 @@
+import { mkdtemp, readFile, readdir, rm, stat, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createMemoryCliIo } from '../../testing/memory-cli-io.js';
+import { scaffoldWorkspace } from './scaffold.js';
+
+describe('scaffoldWorkspace', () => {
+  const templateRoot = fileURLToPath(new URL('../../../templates', import.meta.url));
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = await mkdtemp(path.join(tmpdir(), 'dtifx-init-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it('copies templates, installs dependencies, and initialises git', async () => {
+    const destination = path.join(workspaceRoot, 'demo-project');
+    const commands: Array<{ command: string; args: readonly string[]; cwd: string }> = [];
+    const io = createMemoryCliIo();
+
+    await scaffoldWorkspace({
+      metadata: {
+        name: 'demo-project',
+        displayName: 'Demo Project',
+        packageManager: 'pnpm',
+        includeSampleData: true,
+        initializeGit: true,
+        destination,
+      },
+      io,
+      runCommand: async (command, args, options) => {
+        commands.push({ command, args, cwd: options.cwd });
+      },
+      templateRoot,
+    });
+
+    const files = await readdir(destination);
+    expect(files).toEqual(
+      expect.arrayContaining(['README.md', 'package.json', 'dtifx.config.mjs']),
+    );
+
+    const packageManifest = JSON.parse(
+      await readFile(path.join(destination, 'package.json'), 'utf8'),
+    ) as {
+      readonly name: string;
+      readonly packageManager: string;
+    };
+    expect(packageManifest.name).toBe('demo-project');
+    expect(packageManifest.packageManager).toContain('pnpm');
+
+    const readme = await readFile(path.join(destination, 'README.md'), 'utf8');
+    expect(readme).toContain('Demo Project');
+
+    await expect(stat(path.join(destination, 'tokens', 'foundation.json'))).resolves.toBeDefined();
+    await expect(stat(path.join(destination, 'tokens', 'product.json'))).resolves.toBeDefined();
+
+    expect(commands).toEqual([
+      { command: 'pnpm', args: ['install'], cwd: destination },
+      { command: 'git', args: ['init'], cwd: destination },
+    ]);
+    expect(io.stdoutBuffer).toContain('Scaffolding DTIFx workspace');
+    expect(io.stdoutBuffer).toContain('DTIFx workspace ready');
+  });
+
+  it('skips sample data when requested', async () => {
+    const destination = path.join(workspaceRoot, 'minimal');
+    const io = createMemoryCliIo();
+
+    await scaffoldWorkspace({
+      metadata: {
+        name: 'minimal',
+        displayName: 'Minimal',
+        packageManager: 'npm',
+        includeSampleData: false,
+        initializeGit: false,
+        destination,
+      },
+      io,
+      runCommand: async () => {},
+      templateRoot,
+    });
+
+    await expect(stat(path.join(destination, 'tokens', 'foundation.json'))).rejects.toThrow();
+    const tokenEntries = await readdir(path.join(destination, 'tokens'));
+    expect(tokenEntries).toEqual(expect.arrayContaining(['README.md']));
+  });
+
+  it('throws when the destination is not empty', async () => {
+    const destination = path.join(workspaceRoot, 'existing');
+    await mkdir(destination, { recursive: true });
+    await writeFile(path.join(destination, 'README.md'), '# Existing');
+
+    const io = createMemoryCliIo();
+
+    await expect(
+      scaffoldWorkspace({
+        metadata: {
+          name: 'existing',
+          displayName: 'Existing',
+          packageManager: 'pnpm',
+          includeSampleData: false,
+          initializeGit: false,
+          destination,
+        },
+        io,
+        runCommand: async () => {},
+        templateRoot,
+      }),
+    ).rejects.toThrow('is not empty');
+  });
+});

--- a/packages/cli/src/tools/init/scaffold.ts
+++ b/packages/cli/src/tools/init/scaffold.ts
@@ -1,0 +1,227 @@
+import { spawn } from 'node:child_process';
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+
+import type { CliIo } from '../../io/cli-io.js';
+
+export type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun';
+
+export interface InitMetadata {
+  readonly name: string;
+  readonly displayName: string;
+  readonly packageManager: PackageManager;
+  readonly includeSampleData: boolean;
+  readonly initializeGit: boolean;
+  readonly destination: string;
+}
+
+export interface ScaffoldWorkspaceOptions {
+  readonly metadata: InitMetadata;
+  readonly io: CliIo;
+  readonly runCommand?: RunCommand | undefined;
+  readonly templateRoot?: string | undefined;
+}
+
+type RunCommand = (
+  command: string,
+  args: readonly string[],
+  options: { readonly cwd: string },
+) => Promise<void>;
+
+const packageManagerTags: Record<PackageManager, string> = {
+  pnpm: 'pnpm@9',
+  npm: 'npm@10',
+  yarn: 'yarn@4',
+  bun: 'bun@1',
+};
+
+const packageManagerInstallArgs: Record<PackageManager, readonly string[]> = {
+  pnpm: ['install'],
+  npm: ['install'],
+  yarn: ['install'],
+  bun: ['install'],
+};
+
+const isEnoent = (error: unknown): error is NodeJS.ErrnoException => {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  return 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT';
+};
+
+const ensureEmptyDirectory = async (destination: string): Promise<void> => {
+  try {
+    const stats = await stat(destination);
+    if (!stats.isDirectory()) {
+      throw new Error(`Destination ${destination} exists and is not a directory.`);
+    }
+
+    const entries = await readdir(destination);
+    if (entries.length > 0) {
+      throw new Error(`Destination ${destination} is not empty.`);
+    }
+  } catch (error) {
+    if (isEnoent(error)) {
+      await mkdir(destination, { recursive: true });
+      return;
+    }
+
+    throw error;
+  }
+};
+
+const applyReplacements = (content: string, replacements: Record<string, string>): string => {
+  let result = content;
+  for (const [token, value] of Object.entries(replacements)) {
+    result = result.split(token).join(value);
+  }
+
+  return result;
+};
+
+const copyTemplateDirectory = async (
+  source: string,
+  destination: string,
+  replacements: Record<string, string>,
+): Promise<void> => {
+  await mkdir(destination, { recursive: true });
+  const entries = await readdir(source, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const sourcePath = path.join(source, entry.name);
+    const outputName =
+      entry.isFile() && entry.name.endsWith('.template')
+        ? entry.name.slice(0, -'.template'.length)
+        : entry.name;
+    const destinationPath = path.join(destination, outputName);
+
+    if (entry.isDirectory()) {
+      await copyTemplateDirectory(sourcePath, destinationPath, replacements);
+      continue;
+    }
+
+    if (entry.isFile()) {
+      const content = await readFile(sourcePath, 'utf8');
+      const rendered = applyReplacements(content, replacements);
+      await writeFile(destinationPath, rendered, 'utf8');
+    }
+  }
+};
+
+const findTemplatesRoot = async (override?: string | undefined): Promise<string> => {
+  if (override) {
+    return override;
+  }
+
+  const templateCandidates: string[] = [];
+  let directory = path.dirname(fileURLToPath(import.meta.url));
+
+  for (let index = 0; index < 6; index += 1) {
+    const candidate = path.join(directory, 'templates');
+    templateCandidates.push(candidate);
+    directory = path.dirname(directory);
+  }
+
+  for (const candidate of templateCandidates) {
+    try {
+      const stats = await stat(candidate);
+      if (stats.isDirectory()) {
+        return candidate;
+      }
+    } catch (error) {
+      if (isEnoent(error)) {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  throw new Error('Unable to locate CLI template assets.');
+};
+
+const createDefaultRunCommand =
+  (io: CliIo): RunCommand =>
+  (command, args, options) => {
+    return new Promise((resolve, reject) => {
+      const child = spawn(command, [...args], {
+        cwd: options.cwd,
+        stdio: 'pipe',
+        env: process.env,
+      });
+
+      child.stdout?.on('data', (chunk: Buffer | string) => {
+        io.writeOut(typeof chunk === 'string' ? chunk : chunk.toString());
+      });
+
+      child.stderr?.on('data', (chunk: Buffer | string) => {
+        io.writeErr(typeof chunk === 'string' ? chunk : chunk.toString());
+      });
+
+      child.on('error', (error) => {
+        reject(error);
+      });
+
+      child.on('close', (code) => {
+        if (code === 0) {
+          resolve();
+          return;
+        }
+
+        reject(new Error(`Command ${command} ${args.join(' ')} exited with code ${code}.`));
+      });
+    });
+  };
+
+export const scaffoldWorkspace = async (options: ScaffoldWorkspaceOptions): Promise<void> => {
+  const { metadata, io } = options;
+  const runCommand = options.runCommand ?? createDefaultRunCommand(io);
+  const templateRoot = await findTemplatesRoot(options.templateRoot);
+
+  await ensureEmptyDirectory(metadata.destination);
+
+  const replacements: Record<string, string> = {
+    __PROJECT_NAME__: metadata.displayName,
+    '**PROJECT_NAME**': metadata.displayName,
+    __PACKAGE_NAME__: metadata.name,
+    __PACKAGE_MANAGER_TAG__: packageManagerTags[metadata.packageManager],
+  };
+
+  io.writeOut(`Scaffolding DTIFx workspace in ${metadata.destination}\n`);
+
+  const baseTemplate = path.join(templateRoot, 'base');
+  await copyTemplateDirectory(baseTemplate, metadata.destination, replacements);
+
+  if (metadata.includeSampleData) {
+    const sampleTemplate = path.join(templateRoot, 'sample-data');
+    await copyTemplateDirectory(sampleTemplate, metadata.destination, replacements);
+  }
+
+  const installArgs = packageManagerInstallArgs[metadata.packageManager];
+  io.writeOut(`\nInstalling dependencies with ${metadata.packageManager}…\n`);
+  try {
+    await runCommand(metadata.packageManager, installArgs, { cwd: metadata.destination });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to install dependencies with ${metadata.packageManager}: ${message}`, {
+      cause: error instanceof Error ? error : undefined,
+    });
+  }
+
+  if (metadata.initializeGit) {
+    io.writeOut('\nInitialising Git repository…\n');
+    try {
+      await runCommand('git', ['init'], { cwd: metadata.destination });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to initialise Git repository: ${message}`, {
+        cause: error instanceof Error ? error : undefined,
+      });
+    }
+  }
+
+  io.writeOut('\nDTIFx workspace ready!\n');
+};

--- a/packages/cli/templates/base/.gitignore
+++ b/packages/cli/templates/base/.gitignore
@@ -1,0 +1,13 @@
+# Dependencies
+node_modules
+
+# Build outputs
+dist
+
+# DTIFx cache
+.dtifx-cache
+
+# Tooling
+coverage
+.env
+.DS_Store

--- a/packages/cli/templates/base/README.md
+++ b/packages/cli/templates/base/README.md
@@ -1,0 +1,28 @@
+# **PROJECT_NAME**
+
+This workspace was created with `dtifx init`. It includes a minimal DTIFx configuration so you can
+validate, generate, and audit design token snapshots out of the box.
+
+## Available scripts
+
+The `package.json` file wires convenient npm scripts so you can run DTIFx workflows quickly:
+
+- `pnpm run build:validate` — plan token sources and verify the configuration without writing files.
+- `pnpm run build:generate` — execute the full DTIFx build pipeline and emit formatter artifacts.
+- `pnpm run governance:audit` — execute governance policies against resolved token snapshots.
+- `pnpm run quality:diff` — compare two token snapshots and render a change report.
+
+Replace the `pnpm` invocations with your package manager if you selected a different option while
+initialising the workspace.
+
+## Customising tokens
+
+Add your design token files under `tokens/` and update `dtifx.config.mjs` to point at your sources.
+If you scaffolded sample data you can use it as a reference implementation while integrating your
+own token pipeline.
+
+## Downstream integrations
+
+The `integrations/` directory contains stubs for connecting DTIFx artifacts to downstream
+applications. Populate these folders with the build hooks or delivery automations that your team
+requires.

--- a/packages/cli/templates/base/dtifx.config.mjs
+++ b/packages/cli/templates/base/dtifx.config.mjs
@@ -1,0 +1,35 @@
+/* eslint-disable @nx/enforce-module-boundaries */
+/* eslint-disable import/no-default-export */
+import { defineConfig, placeholder, pointerTemplate } from '@dtifx/build';
+
+export default defineConfig({
+  layers: [{ name: 'foundation' }, { name: 'product' }],
+  sources: [
+    {
+      id: 'tokens.library',
+      layer: 'foundation',
+      kind: 'file',
+      pointerTemplate: pointerTemplate('tokens', placeholder('stem')),
+      patterns: ['tokens/**/*.json'],
+    },
+  ],
+  formatters: [
+    {
+      name: 'json.snapshot',
+      output: { directory: 'dist/snapshots' },
+    },
+    {
+      name: 'css.variables',
+      options: { filename: 'tokens.css' },
+      output: { directory: 'dist/css' },
+    },
+  ],
+  audit: {
+    policies: [
+      {
+        name: 'governance.requireOwner',
+        options: { severity: 'error' },
+      },
+    ],
+  },
+});

--- a/packages/cli/templates/base/integrations/README.md
+++ b/packages/cli/templates/base/integrations/README.md
@@ -1,0 +1,10 @@
+# Downstream integrations
+
+Use this directory to capture any build outputs or automation hooks that distribute DTIF artifacts
+to your consumers. Popular patterns include:
+
+- generating platform modules or SDKs from the resolved artifacts under `dist/`
+- syncing resolved tokens into documentation portals or design linting pipelines
+- wiring CI workflows that validate, generate, and audit DTIF assets on every change
+
+Create additional folders under `integrations/` as you connect DTIFx to your delivery targets.

--- a/packages/cli/templates/base/package.json.template
+++ b/packages/cli/templates/base/package.json.template
@@ -1,0 +1,20 @@
+{
+  "name": "__PACKAGE_NAME__",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Scaffolded DTIFx workspace created with dtifx init.",
+  "type": "module",
+  "packageManager": "__PACKAGE_MANAGER_TAG__",
+  "scripts": {
+    "build:validate": "dtifx build validate",
+    "build:generate": "dtifx build generate",
+    "governance:audit": "dtifx audit run",
+    "quality:diff": "dtifx diff compare"
+  },
+  "devDependencies": {
+    "@dtifx/cli": "latest",
+    "@dtifx/build": "latest",
+    "@dtifx/diff": "latest",
+    "@dtifx/audit": "latest"
+  }
+}

--- a/packages/cli/templates/base/tokens/README.md
+++ b/packages/cli/templates/base/tokens/README.md
@@ -1,0 +1,7 @@
+# Design tokens
+
+Add your design token documents to this directory. The default configuration expects JSON files, but
+you can adjust `dtifx.config.mjs` to accommodate YAML, design tool exports, or custom loaders.
+
+When you opt into the sample data during `dtifx init`, this folder is populated with a reference
+token set that demonstrates DTIF layers, groups, and metadata.

--- a/packages/cli/templates/sample-data/tokens/foundation.json
+++ b/packages/cli/templates/sample-data/tokens/foundation.json
@@ -1,0 +1,69 @@
+{
+  "$version": "1.0.0",
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "$description": "Foundation tokens scaffolded by dtifx init",
+  "colorBrand": {
+    "$type": "color",
+    "$description": "Primary brand color",
+    "$value": {
+      "colorSpace": "oklch",
+      "components": [0.62, 0.16, 264]
+    },
+    "$extensions": {
+      "net.lapidist.governance": {
+        "owner": "Design Systems"
+      },
+      "net.lapidist.tags": ["brand", "released"]
+    }
+  },
+  "colorBackground": {
+    "$type": "color",
+    "$description": "Brand-aligned background token",
+    "$ref": "#/colorBrand",
+    "$extensions": {
+      "net.lapidist.governance": {
+        "owner": "Design Systems"
+      },
+      "net.lapidist.tags": ["background", "released"]
+    }
+  },
+  "spacingBase": {
+    "$type": "dimension",
+    "$description": "Base spacing unit",
+    "$value": {
+      "dimensionType": "length",
+      "value": 8,
+      "unit": "px"
+    },
+    "$extensions": {
+      "net.lapidist.governance": {
+        "owner": "Design Systems"
+      },
+      "net.lapidist.tags": ["spacing"]
+    }
+  },
+  "typographyBody": {
+    "$type": "typography",
+    "$description": "Body text style",
+    "$value": {
+      "fontFamily": "Inter",
+      "fontWeight": 500,
+      "fontSize": {
+        "dimensionType": "length",
+        "value": 16,
+        "unit": "px"
+      },
+      "lineHeight": {
+        "dimensionType": "length",
+        "value": 24,
+        "unit": "px"
+      }
+    },
+    "$extensions": {
+      "net.lapidist.governance": {
+        "owner": "Design Systems"
+      },
+      "net.lapidist.tags": ["typography", "released"]
+    }
+  }
+}

--- a/packages/cli/templates/sample-data/tokens/product.json
+++ b/packages/cli/templates/sample-data/tokens/product.json
@@ -1,0 +1,76 @@
+{
+  "$version": "1.0.0",
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "$description": "Product tokens scaffolded by dtifx init",
+  "colorCta": {
+    "$type": "color",
+    "$description": "Call-to-action surface color",
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [0.9, 0.25, 0.1]
+    },
+    "$extensions": {
+      "net.lapidist.governance": {
+        "owner": "Product"
+      },
+      "net.lapidist.tags": ["product", "released"]
+    }
+  },
+  "colorCtaText": {
+    "$type": "color",
+    "$description": "Call-to-action text color",
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [1, 1, 1]
+    },
+    "$extensions": {
+      "net.lapidist.governance": {
+        "owner": "Product"
+      },
+      "net.lapidist.tags": ["product"]
+    }
+  },
+  "spacingCompact": {
+    "$type": "dimension",
+    "$description": "Compact spacing step",
+    "$value": {
+      "dimensionType": "length",
+      "value": 4,
+      "unit": "px"
+    },
+    "$extensions": {
+      "net.lapidist.governance": {
+        "owner": "Product"
+      },
+      "net.lapidist.tags": ["spacing"]
+    }
+  },
+  "shapeCard": {
+    "$type": "border",
+    "$description": "Card radius and stroke",
+    "$value": {
+      "borderType": "css.border",
+      "width": {
+        "dimensionType": "length",
+        "value": 0,
+        "unit": "px"
+      },
+      "style": "solid",
+      "color": {
+        "$ref": "#/colorCta"
+      },
+      "radius": {
+        "topLeft": { "dimensionType": "length", "unit": "px", "value": 16 },
+        "topRight": { "dimensionType": "length", "unit": "px", "value": 8 },
+        "bottomRight": { "dimensionType": "length", "unit": "px", "value": 8 },
+        "bottomLeft": { "dimensionType": "length", "unit": "px", "value": 24 }
+      }
+    },
+    "$extensions": {
+      "net.lapidist.governance": {
+        "owner": "Product"
+      },
+      "net.lapidist.tags": ["shape"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- remove the Style Dictionary sample stub from the CLI init templates
- adjust the integrations README guidance and update scaffolding tests to cover the sample token assets

## Testing
- `pnpm lint`
- `pnpm lint:markdown`
- `pnpm build`
- `pnpm test`
- `pnpm format:check`
- `pnpm docs:build`


------
https://chatgpt.com/codex/tasks/task_e_68f8ce9ea0c883289949ad15e0f9bb7f