### PR TITLE
chore: ignore changelog markdownlint warnings

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,5 +1,9 @@
 {
   "default": true,
+  "ignores": [
+    ".changeset/**/*.md",
+    "**/CHANGELOG.md"
+  ],
   "MD013": {
     "line_length": 120,
     "heading_line_length": 80,


### PR DESCRIPTION
## Summary
- exclude the `.changeset` markdown entries and project changelog files from markdownlint so duplicate headings no longer cause failures

## Testing
- pnpm lint
- pnpm lint:markdown
- pnpm build *(fails: nx run build:build cannot resolve handlebars type declarations in this environment)*
- pnpm test *(fails: nx run build:test depends on build:build which cannot resolve handlebars type declarations in this environment)*
- pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68f8e87af6bc83288a2c21ff4d4a465e