### PR TITLE
Update extractors logo gradient colors

### DIFF
--- a/docs/public/logos/dtifx-extractors.svg
+++ b/docs/public/logos/dtifx-extractors.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" aria-label="DTIFx Extractors geometric gradient logo" viewBox="0 0 100 100">
   <defs>
     <linearGradient id="a" x1="0" x2="1" y1="0" y2="1">
-      <stop offset="0%" stop-color="#6366f1" />
-      <stop offset="100%" stop-color="#ec4899" />
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#10b981" />
     </linearGradient>
   </defs>
   <circle

--- a/packages/extractors/logo.svg
+++ b/packages/extractors/logo.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" aria-label="DTIFx CLI geometric gradient logo" viewBox="0 0 100 100">
   <defs>
     <linearGradient id="a" x1="0" x2="1" y1="0" y2="1">
-      <stop offset="0%" stop-color="#6366f1" />
-      <stop offset="100%" stop-color="#ec4899" />
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#10b981" />
     </linearGradient>
   </defs>
   <circle


### PR DESCRIPTION
## Summary
- refresh the `@dtifx/extractors` logo gradient to an orange-to-emerald palette in the package asset
- mirror the new gradient colors in the docs-site logo so both assets stay consistent

## Testing
- pnpm lint
- pnpm lint:markdown
- CI=1 pnpm build
- CI=1 pnpm test
- pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68f965fdd31883289c8dcb4e3301021b