### PR TITLE
feat: add prefab builders for fonts, images, panels, and media queries

### DIFF
--- a/.changeset/prefab-library-updates.md
+++ b/.changeset/prefab-library-updates.md
@@ -1,0 +1,5 @@
+---
+'@dtifx/core': minor
+---
+
+Add font, image, panel, and media query token prefabs with responsive helpers and guide updates.

--- a/docs/guides/prefab-library.md
+++ b/docs/guides/prefab-library.md
@@ -1,0 +1,93 @@
+---
+title: Prefab library
+description:
+  Compose high-level token prefabs for fonts, panels, responsive imagery, and media queries.
+outline: deep
+---
+
+# Prefab library
+
+`@dtifx/core` exposes a fluent prefab layer for quickly assembling rich token graphs without hand
+crafting JSON payloads. Each prefab wraps the low-level `TokenPrefab` base class, normalises input,
+provides mutation helpers, and emits a snapshot-ready token value.
+
+## Font prefabs
+
+Use the `FontTokenPrefab` builder to define font families with fallbacks, feature settings, and
+metric metadata:
+
+```ts
+import { FontTokenPrefab } from '@dtifx/core/prefabs';
+
+const heading = FontTokenPrefab.fromFamily(['fonts', 'heading'], 'Inter')
+  .addFallbacks('system-ui', 'Segoe UI')
+  .withWeight(600)
+  .withMetrics({ ascent: 0.92, descent: -0.24 })
+  .setFeature('liga', 1);
+```
+
+The prefab trims and deduplicates fallbacks, rejects empty feature names, and preserves optional
+fields only when values are supplied. Use `withWeight(undefined)` or `setFeature(name, undefined)`
+to clear previously assigned metadata.
+
+## Image prefabs
+
+Image prefabs model responsive asset metadata. The `responsive` helper builds pixel-ratio aware
+source sets using a predictable naming convention:
+
+```ts
+import { ImageTokenPrefab } from '@dtifx/core/prefabs';
+
+const hero = ImageTokenPrefab.responsive(['media', 'hero'], 'hero.png', {
+  alt: 'Product hero illustration',
+  pixelRatios: [1, 2, 3],
+});
+```
+
+Additional sources can be appended with `addSources`, and metadata such as `alt` text or
+placeholders can be cleared by passing `undefined`. Use `assertValidPixelRatio` when validating
+user-supplied configurations before handing them to the prefab layer.
+
+## Panel prefabs
+
+Panel prefabs capture layered surfaces that combine fills, shadows, padding, and radius metadata.
+All spacing helpers accept single values, CSS-like tuples, or explicit side objects. Invalid layer
+kinds, negative spacing, and empty token references are rejected during normalisation.
+
+```ts
+import { PanelTokenPrefab } from '@dtifx/core/prefabs';
+
+const card = PanelTokenPrefab.create(['components', 'card'], {
+  panelType: 'surface',
+  layers: [
+    { kind: 'fill', token: 'color.surface' },
+    { kind: 'shadow', token: 'shadow.raised', opacity: 0.4 },
+  ],
+})
+  .withPadding([16, 24])
+  .withRadius(12);
+```
+
+## Media query prefabs
+
+Media query prefabs provide a structural way to construct common responsive breakpoints without
+interpolating strings. Pass constraint objects and the prefab will generate a canonical media query
+string:
+
+```ts
+import { MediaQueryTokenPrefab } from '@dtifx/core/prefabs';
+
+const tablet = MediaQueryTokenPrefab.forWidthRange(['queries', 'tablet'], {
+  mediaType: 'screen',
+  min: 768,
+  max: 1024,
+});
+```
+
+Call `addConstraint` or `withConstraints` to extend the query, or `withWidthRange` to replace
+existing width rules. Use `isValidMediaFeatureName` to preflight media features submitted by users.
+
+## Serialisation
+
+Each prefab exposes `toJSON()` and `toSnapshot()` from the `TokenPrefab` base class. When composed
+with other prefabs they produce ready-to-serialise token graphs with consistent metadata handling.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -64,6 +64,41 @@ try {
 Use the policy helpers to define governance rules, validate DTIF structures, and share policy
 metadata across build and audit workflows.
 
+### Token prefabs
+
+Prefab builders streamline the process of emitting serialisable token values with consistent
+metadata handling:
+
+```ts
+import {
+  FontTokenPrefab,
+  ImageTokenPrefab,
+  PanelTokenPrefab,
+  MediaQueryTokenPrefab,
+} from '@dtifx/core/prefabs';
+
+const heading = FontTokenPrefab.fromFamily(['fonts', 'heading'], 'Inter')
+  .addFallbacks('system-ui')
+  .withWeight(600);
+
+const hero = ImageTokenPrefab.responsive(['media', 'hero'], 'hero.png', { pixelRatios: [1, 2, 3] });
+
+const surface = PanelTokenPrefab.create(['components', 'card'], {
+  layers: [
+    { kind: 'fill', token: 'color.surface' },
+    { kind: 'shadow', token: 'shadow.raised', opacity: 0.4 },
+  ],
+}).withPadding([16, 24]);
+
+const tablet = MediaQueryTokenPrefab.forWidthRange(['queries', 'tablet'], {
+  mediaType: 'screen',
+  min: 768,
+});
+```
+
+Each prefab extends the shared `TokenPrefab` base class so you can call `toJSON()` or `toSnapshot()`
+and merge the output into larger token graphs.
+
 ## Examples
 
 - [Telemetry overview](../../docs/overview/telemetry.md)

--- a/packages/core/src/prefabs/font.spec.ts
+++ b/packages/core/src/prefabs/font.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { FontTokenPrefab } from './font.js';
+
+describe('FontTokenPrefab', () => {
+  it('normalises families and fallbacks', () => {
+    const prefab = FontTokenPrefab.fromFamily(['fonts', 'heading'], '  Inter  ', [
+      '  system-ui  ',
+      '  Inter  ',
+    ]);
+
+    expect(prefab.value.family).toBe('Inter');
+    expect(prefab.value.fallbacks).toEqual(['system-ui']);
+  });
+
+  it('merges fallbacks and removes duplicates', () => {
+    const prefab = FontTokenPrefab.fromFamily(['fonts', 'body'], 'Source Sans Pro');
+    const updated = prefab.addFallbacks('system-ui', '  Georgia  ', 'system-ui');
+
+    expect(updated.value.fallbacks).toEqual(['system-ui', 'Georgia']);
+    expect(prefab.value.fallbacks).toEqual([]);
+  });
+
+  it('clears optional metadata when undefined is provided', () => {
+    const prefab = FontTokenPrefab.create(['fonts', 'caption'], {
+      family: 'Source Code Pro',
+      weight: 600,
+      style: 'italic',
+      display: 'swap',
+    });
+
+    const cleared = prefab.withWeight().withStyle().withDisplay();
+    expect(cleared.value.weight).toBeUndefined();
+    expect(cleared.value.style).toBeUndefined();
+    expect(cleared.value.display).toBeUndefined();
+  });
+
+  it('applies metrics and features through fluent helpers', () => {
+    const prefab = FontTokenPrefab.fromFamily(['fonts', 'ui'], 'Inter');
+    const updated = prefab
+      .withMetrics({ ascent: 0.9, descent: -0.2 })
+      .setFeature('liga', 1)
+      .setFeature('kern', 'on');
+
+    expect(updated.value.metrics).toEqual({ ascent: 0.9, descent: -0.2 });
+    expect(updated.value.features).toEqual({ liga: 1, kern: 'on' });
+
+    const removed = updated.setFeature('liga', undefined);
+    expect(removed.value.features).toEqual({ kern: 'on' });
+  });
+
+  it('throws when the family name is empty', () => {
+    expect(() => FontTokenPrefab.fromFamily(['fonts', 'broken'], '   ')).toThrowError(TypeError);
+  });
+});

--- a/packages/core/src/prefabs/font.ts
+++ b/packages/core/src/prefabs/font.ts
@@ -1,0 +1,464 @@
+import {
+  TokenPrefab,
+  createInitialState,
+  normaliseTokenPath,
+  type TokenPathInput,
+} from './token-prefab.js';
+import type { TokenPath } from '../tokens/index.js';
+
+export interface FontMetrics {
+  readonly ascent?: number;
+  readonly descent?: number;
+  readonly lineGap?: number;
+  readonly unitsPerEm?: number;
+}
+
+export interface FontOptions {
+  readonly fontType?: string;
+  readonly family: string;
+  readonly fallbacks?: Iterable<string>;
+  readonly weight?: number | string;
+  readonly style?: string;
+  readonly display?: string;
+  readonly metrics?: FontMetrics;
+  readonly features?: Readonly<Record<string, string | number>>;
+}
+
+export interface FontValue {
+  readonly fontType?: string;
+  readonly family: string;
+  readonly fallbacks: readonly string[];
+  readonly weight?: number | string;
+  readonly style?: string;
+  readonly display?: string;
+  readonly metrics?: FontMetrics;
+  readonly features?: Readonly<Record<string, string | number>>;
+}
+
+type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+
+export class FontTokenPrefab extends TokenPrefab<FontValue, FontTokenPrefab> {
+  static create(path: TokenPathInput, options: FontOptions): FontTokenPrefab {
+    const tokenPath = normaliseTokenPath(path);
+    const value = normaliseFontValue(options);
+    return new FontTokenPrefab(tokenPath, createInitialState(value));
+  }
+
+  static fromFamily(
+    path: TokenPathInput,
+    family: string,
+    fallbacks: Iterable<string> = [],
+  ): FontTokenPrefab {
+    return FontTokenPrefab.create(path, { family, fallbacks });
+  }
+
+  private constructor(path: TokenPath, state: ReturnType<typeof createInitialState<FontValue>>) {
+    super('font', path, state);
+  }
+
+  protected create(
+    path: TokenPath,
+    state: ReturnType<typeof createInitialState<FontValue>>,
+  ): FontTokenPrefab {
+    return new FontTokenPrefab(path, state);
+  }
+
+  get value(): FontValue {
+    return this.state.value;
+  }
+
+  withFontType(fontType?: string): FontTokenPrefab {
+    if (fontType === undefined) {
+      return this.updateValue((current) =>
+        rebuildFontValue(current, {
+          clearFontType: true,
+        }),
+      );
+    }
+
+    return this.updateValue((current) =>
+      rebuildFontValue(current, {
+        fontType: normaliseFontType(fontType),
+      }),
+    );
+  }
+
+  withFamily(family: string): FontTokenPrefab {
+    return this.updateValue((current) =>
+      rebuildFontValue(current, {
+        family: normaliseFontFamily(family),
+      }),
+    );
+  }
+
+  withFallbacks(fallbacks: Iterable<string>): FontTokenPrefab {
+    return this.updateValue((current) =>
+      rebuildFontValue(current, {
+        fallbacks: normaliseFontFallbacks(fallbacks, current.family),
+      }),
+    );
+  }
+
+  addFallbacks(...fallbacks: readonly string[]): FontTokenPrefab {
+    const combined = [...this.state.value.fallbacks, ...fallbacks];
+    return this.withFallbacks(combined);
+  }
+
+  withWeight(weight?: number | string): FontTokenPrefab {
+    if (weight === undefined) {
+      return this.updateValue((current) =>
+        rebuildFontValue(current, {
+          clearWeight: true,
+        }),
+      );
+    }
+
+    return this.updateValue((current) =>
+      rebuildFontValue(current, {
+        weight: normaliseFontWeight(weight),
+      }),
+    );
+  }
+
+  withStyle(style?: string): FontTokenPrefab {
+    if (style === undefined) {
+      return this.updateValue((current) =>
+        rebuildFontValue(current, {
+          clearStyle: true,
+        }),
+      );
+    }
+
+    return this.updateValue((current) =>
+      rebuildFontValue(current, {
+        style: normaliseFontStyle(style),
+      }),
+    );
+  }
+
+  withDisplay(display?: string): FontTokenPrefab {
+    if (display === undefined) {
+      return this.updateValue((current) =>
+        rebuildFontValue(current, {
+          clearDisplay: true,
+        }),
+      );
+    }
+
+    return this.updateValue((current) =>
+      rebuildFontValue(current, {
+        display: normaliseFontDisplay(display),
+      }),
+    );
+  }
+
+  withMetrics(metrics?: FontMetrics): FontTokenPrefab {
+    if (metrics === undefined) {
+      return this.updateValue((current) =>
+        rebuildFontValue(current, {
+          clearMetrics: true,
+        }),
+      );
+    }
+
+    return this.updateValue((current) =>
+      rebuildFontValue(current, {
+        metrics: normaliseFontMetrics(metrics),
+      }),
+    );
+  }
+
+  withFeatures(features?: Readonly<Record<string, string | number>>): FontTokenPrefab {
+    if (features === undefined) {
+      return this.updateValue((current) =>
+        rebuildFontValue(current, {
+          clearFeatures: true,
+        }),
+      );
+    }
+
+    return this.updateValue((current) =>
+      rebuildFontValue(current, {
+        features: normaliseFontFeatures(features),
+      }),
+    );
+  }
+
+  setFeature(name: string, value: string | number | undefined): FontTokenPrefab {
+    const featureName = normaliseFeatureName(name);
+
+    if (value === undefined) {
+      const existing = this.state.value.features ?? {};
+      const remaining = { ...existing } as Record<string, string | number>;
+      delete remaining[featureName];
+      return this.withFeatures(Object.keys(remaining).length === 0 ? undefined : remaining);
+    }
+
+    return this.updateValue((current) => {
+      const existing = current.features ?? {};
+      const nextFeatures = {
+        ...existing,
+        [featureName]: normaliseFeatureValue(value),
+      } as Readonly<Record<string, string | number>>;
+      return rebuildFontValue(current, {
+        features: normaliseFontFeatures(nextFeatures),
+      });
+    });
+  }
+}
+
+export const Font = {
+  create: FontTokenPrefab.create,
+  fromFamily: FontTokenPrefab.fromFamily,
+};
+
+interface FontOverrides {
+  readonly fontType?: string;
+  readonly clearFontType?: boolean;
+  readonly family?: string;
+  readonly fallbacks?: readonly string[];
+  readonly weight?: number | string;
+  readonly clearWeight?: boolean;
+  readonly style?: string;
+  readonly clearStyle?: boolean;
+  readonly display?: string;
+  readonly clearDisplay?: boolean;
+  readonly metrics?: FontMetrics;
+  readonly clearMetrics?: boolean;
+  readonly features?: Readonly<Record<string, string | number>>;
+  readonly clearFeatures?: boolean;
+}
+
+function normaliseFontValue(options: FontOptions): FontValue {
+  const family = normaliseFontFamily(options.family);
+  const fallbacks = normaliseFontFallbacks(options.fallbacks ?? [], family);
+
+  const result: Mutable<FontValue> = {
+    family,
+    fallbacks,
+  };
+
+  if (options.fontType !== undefined) {
+    result.fontType = normaliseFontType(options.fontType);
+  }
+
+  if (options.weight !== undefined) {
+    result.weight = normaliseFontWeight(options.weight);
+  }
+
+  if (options.style !== undefined) {
+    result.style = normaliseFontStyle(options.style);
+  }
+
+  if (options.display !== undefined) {
+    result.display = normaliseFontDisplay(options.display);
+  }
+
+  if (options.metrics !== undefined) {
+    result.metrics = normaliseFontMetrics(options.metrics);
+  }
+
+  if (options.features !== undefined) {
+    result.features = normaliseFontFeatures(options.features);
+  }
+
+  return result;
+}
+
+function rebuildFontValue(value: FontValue, overrides: FontOverrides): FontValue {
+  const family = normaliseFontFamily(overrides.family ?? value.family);
+  const fallbacks = normaliseFontFallbacks(overrides.fallbacks ?? value.fallbacks, family);
+
+  let fontType = value.fontType;
+  if (overrides.clearFontType === true) {
+    fontType = undefined;
+  } else if (overrides.fontType !== undefined) {
+    fontType = normaliseFontType(overrides.fontType);
+  }
+
+  let weight = value.weight;
+  if (overrides.clearWeight === true) {
+    weight = undefined;
+  } else if (overrides.weight !== undefined) {
+    weight = normaliseFontWeight(overrides.weight);
+  }
+
+  let style = value.style;
+  if (overrides.clearStyle === true) {
+    style = undefined;
+  } else if (overrides.style !== undefined) {
+    style = normaliseFontStyle(overrides.style);
+  }
+
+  let display = value.display;
+  if (overrides.clearDisplay === true) {
+    display = undefined;
+  } else if (overrides.display !== undefined) {
+    display = normaliseFontDisplay(overrides.display);
+  }
+
+  let metrics = value.metrics;
+  if (overrides.clearMetrics === true) {
+    metrics = undefined;
+  } else if (overrides.metrics !== undefined) {
+    metrics = normaliseFontMetrics(overrides.metrics);
+  }
+
+  let features = value.features;
+  if (overrides.clearFeatures === true) {
+    features = undefined;
+  } else if (overrides.features !== undefined) {
+    features = normaliseFontFeatures(overrides.features);
+  }
+
+  const result: Mutable<FontValue> = {
+    family,
+    fallbacks,
+  };
+
+  if (fontType) {
+    result.fontType = fontType;
+  }
+
+  if (weight !== undefined) {
+    result.weight = weight;
+  }
+
+  if (style !== undefined) {
+    result.style = style;
+  }
+
+  if (display !== undefined) {
+    result.display = display;
+  }
+
+  if (metrics !== undefined) {
+    result.metrics = metrics;
+  }
+
+  if (features !== undefined) {
+    result.features = features;
+  }
+
+  return result;
+}
+
+function normaliseFontType(fontType: string): string {
+  const trimmed = fontType.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Font type cannot be empty.');
+  }
+  return trimmed;
+}
+
+function normaliseFontFamily(family: string): string {
+  const trimmed = family.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Font family cannot be empty.');
+  }
+  return trimmed;
+}
+
+function normaliseFontFallbacks(fallbacks: Iterable<string>, family?: string): readonly string[] {
+  const unique = new Set<string>();
+  for (const fallback of fallbacks) {
+    const trimmed = fallback.trim();
+    if (trimmed.length > 0 && trimmed !== family) {
+      unique.add(trimmed);
+    }
+  }
+  return [...unique];
+}
+
+function normaliseFontWeight(weight: number | string): number | string {
+  if (typeof weight === 'number') {
+    if (!Number.isFinite(weight)) {
+      throw new TypeError('Font weight numbers must be finite.');
+    }
+    return weight;
+  }
+
+  const trimmed = weight.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Font weight strings cannot be empty.');
+  }
+  return trimmed;
+}
+
+function normaliseFontStyle(style: string): string {
+  const trimmed = style.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Font style cannot be empty.');
+  }
+  return trimmed;
+}
+
+function normaliseFontDisplay(display: string): string {
+  const trimmed = display.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Font display cannot be empty.');
+  }
+  return trimmed;
+}
+
+function normaliseFontMetrics(metrics: FontMetrics): FontMetrics {
+  const ascent =
+    metrics.ascent === undefined ? undefined : normaliseMetricNumber('ascent', metrics.ascent);
+  const descent =
+    metrics.descent === undefined ? undefined : normaliseMetricNumber('descent', metrics.descent);
+  const lineGap =
+    metrics.lineGap === undefined ? undefined : normaliseMetricNumber('lineGap', metrics.lineGap);
+  const unitsPerEm =
+    metrics.unitsPerEm === undefined
+      ? undefined
+      : normaliseMetricNumber('unitsPerEm', metrics.unitsPerEm);
+
+  const result: FontMetrics = {
+    ...(ascent === undefined ? {} : { ascent }),
+    ...(descent === undefined ? {} : { descent }),
+    ...(lineGap === undefined ? {} : { lineGap }),
+    ...(unitsPerEm === undefined ? {} : { unitsPerEm }),
+  };
+
+  return result;
+}
+
+function normaliseMetricNumber(name: string, value: number): number {
+  if (!Number.isFinite(value)) {
+    throw new TypeError(`${name} must be a finite number.`);
+  }
+  return value;
+}
+
+function normaliseFontFeatures(
+  features: Readonly<Record<string, string | number>>,
+): Readonly<Record<string, string | number>> {
+  const entries = Object.entries(features).map(
+    ([featureName, featureValue]) =>
+      [normaliseFeatureName(featureName), normaliseFeatureValue(featureValue)] as const,
+  );
+  return Object.fromEntries(entries);
+}
+
+function normaliseFeatureName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Font feature name cannot be empty.');
+  }
+  return trimmed;
+}
+
+function normaliseFeatureValue(value: string | number): string | number {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new TypeError('Font feature values must be finite numbers.');
+    }
+    return value;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Font feature values cannot be empty.');
+  }
+  return trimmed;
+}

--- a/packages/core/src/prefabs/image.spec.ts
+++ b/packages/core/src/prefabs/image.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { ImageTokenPrefab } from './image.js';
+
+describe('ImageTokenPrefab', () => {
+  it('builds responsive sources with default ratios', () => {
+    const prefab = ImageTokenPrefab.responsive(['media', 'hero'], 'hero.png', {
+      alt: 'Hero illustration',
+    });
+
+    expect(prefab.value.sources).toEqual([
+      { src: 'hero.png', pixelRatio: 1 },
+      { src: 'hero@2x.png', pixelRatio: 2 },
+    ]);
+    expect(prefab.value.alt).toBe('Hero illustration');
+  });
+
+  it('clears optional metadata when undefined is provided', () => {
+    const prefab = ImageTokenPrefab.create(['media', 'logo'], {
+      alt: 'Company logo',
+      placeholder: 'logo.svg',
+      sources: [{ src: 'logo.svg' }],
+    });
+
+    const cleared = prefab.withAlt().withPlaceholder();
+    expect(cleared.value.alt).toBeUndefined();
+    expect(cleared.value.placeholder).toBeUndefined();
+  });
+
+  it('adds additional sources while removing duplicates', () => {
+    const prefab = ImageTokenPrefab.create(['media', 'icon'], {
+      sources: [{ src: 'icon.png', pixelRatio: 1 }],
+    });
+
+    const updated = prefab.addSources(
+      { src: 'icon.png', pixelRatio: 2 },
+      { src: 'icon@3x.png', pixelRatio: 3 },
+    );
+    expect(updated.value.sources).toEqual([
+      { src: 'icon.png', pixelRatio: 1 },
+      { src: 'icon@3x.png', pixelRatio: 3 },
+    ]);
+  });
+
+  it('throws when an invalid pixel ratio is provided', () => {
+    expect(() =>
+      ImageTokenPrefab.create(['media', 'bad'], {
+        sources: [{ src: 'broken.png', pixelRatio: 0 }],
+      }),
+    ).toThrowError(TypeError);
+  });
+});

--- a/packages/core/src/prefabs/image.ts
+++ b/packages/core/src/prefabs/image.ts
@@ -1,0 +1,400 @@
+import {
+  TokenPrefab,
+  createInitialState,
+  normaliseTokenPath,
+  type TokenPathInput,
+} from './token-prefab.js';
+import type { TokenPath } from '../tokens/index.js';
+
+export interface ImageSource {
+  readonly src: string;
+  readonly pixelRatio?: number;
+  readonly width?: number;
+  readonly height?: number;
+  readonly media?: string;
+  readonly format?: string;
+}
+
+export interface ImageOptions {
+  readonly imageType?: string;
+  readonly alt?: string;
+  readonly placeholder?: string;
+  readonly sources: Iterable<ImageSource>;
+}
+
+export interface ImageValue {
+  readonly imageType?: string;
+  readonly alt?: string;
+  readonly placeholder?: string;
+  readonly sources: readonly ImageSource[];
+}
+
+export interface ResponsiveImageOptions {
+  readonly pixelRatios?: readonly number[];
+  readonly width?: number;
+  readonly height?: number;
+  readonly media?: string;
+  readonly format?: string;
+  readonly buildSrc?: (base: string, pixelRatio: number) => string;
+}
+
+type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+
+export class ImageTokenPrefab extends TokenPrefab<ImageValue, ImageTokenPrefab> {
+  static create(path: TokenPathInput, options: ImageOptions): ImageTokenPrefab {
+    const tokenPath = normaliseTokenPath(path);
+    const value = normaliseImageValue(options);
+    return new ImageTokenPrefab(tokenPath, createInitialState(value));
+  }
+
+  static responsive(
+    path: TokenPathInput,
+    base: string,
+    options: Omit<ImageOptions, 'sources'> & ResponsiveImageOptions = {},
+  ): ImageTokenPrefab {
+    const sources = buildResponsiveSources(base, options);
+    const createOptions: Mutable<Partial<ImageOptions>> = {};
+    createOptions.sources = sources;
+
+    if (options.imageType !== undefined) {
+      createOptions.imageType = options.imageType;
+    }
+
+    if (options.alt !== undefined) {
+      createOptions.alt = options.alt;
+    }
+
+    if (options.placeholder !== undefined) {
+      createOptions.placeholder = options.placeholder;
+    }
+
+    return ImageTokenPrefab.create(path, createOptions as ImageOptions);
+  }
+
+  private constructor(path: TokenPath, state: ReturnType<typeof createInitialState<ImageValue>>) {
+    super('image', path, state);
+  }
+
+  protected create(
+    path: TokenPath,
+    state: ReturnType<typeof createInitialState<ImageValue>>,
+  ): ImageTokenPrefab {
+    return new ImageTokenPrefab(path, state);
+  }
+
+  get value(): ImageValue {
+    return this.state.value;
+  }
+
+  withImageType(imageType?: string): ImageTokenPrefab {
+    if (imageType === undefined) {
+      return this.updateValue((current) =>
+        rebuildImageValue(current, {
+          clearImageType: true,
+        }),
+      );
+    }
+
+    return this.updateValue((current) =>
+      rebuildImageValue(current, {
+        imageType: normaliseImageType(imageType),
+      }),
+    );
+  }
+
+  withAlt(alt?: string): ImageTokenPrefab {
+    if (alt === undefined) {
+      return this.updateValue((current) =>
+        rebuildImageValue(current, {
+          clearAlt: true,
+        }),
+      );
+    }
+
+    return this.updateValue((current) =>
+      rebuildImageValue(current, {
+        alt: normaliseAltText(alt),
+      }),
+    );
+  }
+
+  withPlaceholder(placeholder?: string): ImageTokenPrefab {
+    if (placeholder === undefined) {
+      return this.updateValue((current) =>
+        rebuildImageValue(current, {
+          clearPlaceholder: true,
+        }),
+      );
+    }
+
+    return this.updateValue((current) =>
+      rebuildImageValue(current, {
+        placeholder: normalisePlaceholder(placeholder),
+      }),
+    );
+  }
+
+  withSources(sources: Iterable<ImageSource>): ImageTokenPrefab {
+    return this.updateValue((current) =>
+      rebuildImageValue(current, {
+        sources: normaliseImageSources(sources),
+      }),
+    );
+  }
+
+  addSources(...sources: readonly ImageSource[]): ImageTokenPrefab {
+    const combined = [...this.state.value.sources, ...sources];
+    return this.withSources(combined);
+  }
+
+  withResponsiveSources(base: string, options: ResponsiveImageOptions = {}): ImageTokenPrefab {
+    const sources = buildResponsiveSources(base, options);
+    return this.withSources(sources);
+  }
+}
+
+export const Image = {
+  create: ImageTokenPrefab.create,
+  responsive: ImageTokenPrefab.responsive,
+};
+
+interface ImageOverrides {
+  readonly imageType?: string;
+  readonly clearImageType?: boolean;
+  readonly alt?: string;
+  readonly clearAlt?: boolean;
+  readonly placeholder?: string;
+  readonly clearPlaceholder?: boolean;
+  readonly sources?: readonly ImageSource[];
+}
+
+/**
+ * Ensures that a pixel ratio is finite and greater than zero before recording it in metadata.
+ *
+ * @param pixelRatio - The candidate pixel ratio provided by the caller.
+ * @throws {TypeError} When the ratio is infinite, NaN, or non-positive.
+ */
+export function assertValidPixelRatio(pixelRatio: number): void {
+  if (!Number.isFinite(pixelRatio) || pixelRatio <= 0) {
+    throw new TypeError('Pixel ratio must be a finite number greater than zero.');
+  }
+}
+
+function normaliseImageValue(options: ImageOptions): ImageValue {
+  const result: Mutable<ImageValue> = {
+    sources: normaliseImageSources(options.sources),
+  };
+
+  if (options.imageType !== undefined) {
+    result.imageType = normaliseImageType(options.imageType);
+  }
+
+  if (options.alt !== undefined) {
+    result.alt = normaliseAltText(options.alt);
+  }
+
+  if (options.placeholder !== undefined) {
+    result.placeholder = normalisePlaceholder(options.placeholder);
+  }
+
+  return result;
+}
+
+function rebuildImageValue(value: ImageValue, overrides: ImageOverrides): ImageValue {
+  let imageType = value.imageType;
+  if (overrides.clearImageType === true) {
+    imageType = undefined;
+  } else if (overrides.imageType !== undefined) {
+    imageType = normaliseImageType(overrides.imageType);
+  }
+
+  let alt = value.alt;
+  if (overrides.clearAlt === true) {
+    alt = undefined;
+  } else if (overrides.alt !== undefined) {
+    alt = normaliseAltText(overrides.alt);
+  }
+
+  let placeholder = value.placeholder;
+  if (overrides.clearPlaceholder === true) {
+    placeholder = undefined;
+  } else if (overrides.placeholder !== undefined) {
+    placeholder = normalisePlaceholder(overrides.placeholder);
+  }
+
+  const sources = normaliseImageSources(overrides.sources ?? value.sources);
+
+  const result: Mutable<ImageValue> = {
+    sources,
+  };
+
+  if (imageType !== undefined) {
+    result.imageType = imageType;
+  }
+
+  if (alt !== undefined) {
+    result.alt = alt;
+  }
+
+  if (placeholder !== undefined) {
+    result.placeholder = placeholder;
+  }
+
+  return result;
+}
+
+function normaliseImageType(imageType: string): string {
+  const trimmed = imageType.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Image type cannot be empty.');
+  }
+  return trimmed;
+}
+
+function normaliseAltText(alt: string): string {
+  const trimmed = alt.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Image alt text cannot be empty.');
+  }
+  return trimmed;
+}
+
+function normalisePlaceholder(placeholder: string): string {
+  const trimmed = placeholder.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Image placeholder cannot be empty.');
+  }
+  return trimmed;
+}
+
+function normaliseImageSources(sources: Iterable<ImageSource>): readonly ImageSource[] {
+  const normalised: ImageSource[] = [];
+  const seen = new Set<string>();
+
+  for (const source of sources) {
+    const entry = normaliseImageSource(source);
+    if (!seen.has(entry.src)) {
+      normalised.push(entry);
+      seen.add(entry.src);
+    }
+  }
+
+  if (normalised.length === 0) {
+    throw new TypeError('At least one image source must be provided.');
+  }
+
+  return normalised;
+}
+
+function normaliseImageSource(source: ImageSource): ImageSource {
+  const result: Mutable<ImageSource> = {
+    src: normaliseSourceUri(source.src),
+  };
+
+  if (source.pixelRatio !== undefined) {
+    result.pixelRatio = normalisePixelRatio(source.pixelRatio);
+  }
+
+  if (source.width !== undefined) {
+    result.width = normaliseDimension('width', source.width);
+  }
+
+  if (source.height !== undefined) {
+    result.height = normaliseDimension('height', source.height);
+  }
+
+  if (source.media !== undefined) {
+    result.media = normaliseMediaCondition(source.media);
+  }
+
+  if (source.format !== undefined) {
+    result.format = normaliseFormat(source.format);
+  }
+
+  return result;
+}
+
+function normaliseSourceUri(src: string): string {
+  const trimmed = src.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Image source URI cannot be empty.');
+  }
+  return trimmed;
+}
+
+function normalisePixelRatio(pixelRatio: number): number {
+  assertValidPixelRatio(pixelRatio);
+  return pixelRatio;
+}
+
+function normaliseDimension(name: string, value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new TypeError(`Image ${name} must be a positive, finite number.`);
+  }
+  return value;
+}
+
+function normaliseMediaCondition(media: string): string {
+  const trimmed = media.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Image media condition cannot be empty.');
+  }
+  return trimmed;
+}
+
+function normaliseFormat(format: string): string {
+  const trimmed = format.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Image format cannot be empty.');
+  }
+  return trimmed.toLowerCase();
+}
+
+function buildResponsiveSources(
+  base: string,
+  options: ResponsiveImageOptions,
+): readonly ImageSource[] {
+  const pixelRatios = normalisePixelRatios(options.pixelRatios ?? [1, 2]);
+  const buildSrc = options.buildSrc ?? defaultResponsiveSrcBuilder;
+
+  return pixelRatios.map((ratio) =>
+    normaliseImageSource({
+      src: buildSrc(base, ratio),
+      pixelRatio: ratio,
+      ...(options.width === undefined ? {} : { width: options.width }),
+      ...(options.height === undefined ? {} : { height: options.height }),
+      ...(options.media === undefined ? {} : { media: options.media }),
+      ...(options.format === undefined ? {} : { format: options.format }),
+    }),
+  );
+}
+
+function normalisePixelRatios(pixelRatios: readonly number[]): readonly number[] {
+  const ratios = pixelRatios.map((ratio) => {
+    assertValidPixelRatio(ratio);
+    return ratio;
+  });
+
+  const unique = [...new Set(ratios)].toSorted((a, b) => a - b);
+  if (unique.length === 0) {
+    throw new TypeError('Responsive images require at least one pixel ratio.');
+  }
+
+  return unique;
+}
+
+function defaultResponsiveSrcBuilder(base: string, pixelRatio: number): string {
+  if (pixelRatio === 1) {
+    return normaliseSourceUri(base);
+  }
+
+  const trimmed = normaliseSourceUri(base);
+  const extensionIndex = trimmed.lastIndexOf('.');
+  if (extensionIndex === -1) {
+    return `${trimmed}@${pixelRatio}x`;
+  }
+
+  const name = trimmed.slice(0, extensionIndex);
+  const extension = trimmed.slice(extensionIndex);
+  return `${name}@${pixelRatio}x${extension}`;
+}

--- a/packages/core/src/prefabs/index.ts
+++ b/packages/core/src/prefabs/index.ts
@@ -1,4 +1,42 @@
 export {
+  Font,
+  FontTokenPrefab,
+  type FontMetrics,
+  type FontOptions,
+  type FontValue,
+} from './font.js';
+export {
+  Image,
+  ImageTokenPrefab,
+  assertValidPixelRatio,
+  type ImageOptions,
+  type ImageSource,
+  type ImageValue,
+  type ResponsiveImageOptions,
+} from './image.js';
+export {
+  Panel,
+  PanelTokenPrefab,
+  type PanelLayer,
+  type PanelLayerInput,
+  type PanelLayerKind,
+  type PanelOptions,
+  type PanelSpace,
+  type PanelSpaceInput,
+  type PanelValue,
+} from './panel.js';
+export {
+  MediaQuery,
+  MediaQueryTokenPrefab,
+  isValidMediaFeatureName,
+  type MediaConstraintComparison,
+  type MediaQueryConstraint,
+  type MediaQueryConstraintInput,
+  type MediaQueryOptions,
+  type MediaQueryValue,
+  type WidthRangeOptions,
+} from './media-query.js';
+export {
   Color,
   ColorTokenPrefab,
   darkenColorValue,

--- a/packages/core/src/prefabs/media-query.spec.ts
+++ b/packages/core/src/prefabs/media-query.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { MediaQueryTokenPrefab } from './media-query.js';
+
+describe('MediaQueryTokenPrefab', () => {
+  it('creates queries from structured constraints', () => {
+    const prefab = MediaQueryTokenPrefab.create(['queries', 'tablet'], {
+      mediaType: 'screen',
+      constraints: [
+        { feature: 'width', comparison: 'min', value: 768, unit: 'px' },
+        { feature: 'prefers-color-scheme', value: 'dark' },
+      ],
+    });
+
+    expect(prefab.value.query).toBe(
+      'screen and (min-width: 768px) and (prefers-color-scheme: dark)',
+    );
+  });
+
+  it('adds constraints via fluent helpers', () => {
+    const prefab = MediaQueryTokenPrefab.create(['queries', 'hover'], {
+      constraints: [],
+    });
+
+    const updated = prefab.addConstraint({ feature: 'hover', value: 'hover' });
+    expect(updated.value.constraints).toEqual([
+      { feature: 'hover', comparison: 'exact', value: 'hover' },
+    ]);
+    expect(updated.value.query).toBe('all and (hover: hover)');
+  });
+
+  it('replaces width constraints when withWidthRange is used', () => {
+    const prefab = MediaQueryTokenPrefab.create(['queries', 'range'], {
+      constraints: [{ feature: 'height', comparison: 'min', value: 600, unit: 'px' }],
+    });
+
+    const updated = prefab.withWidthRange({ min: 320, max: 960 });
+    expect(updated.value.query).toBe(
+      'all and (min-height: 600px) and (min-width: 320px) and (max-width: 960px)',
+    );
+  });
+
+  it('throws for invalid feature names', () => {
+    expect(() =>
+      MediaQueryTokenPrefab.create(['queries', 'broken'], {
+        constraints: [{ feature: '123invalid', value: 'bad' }],
+      }),
+    ).toThrowError(TypeError);
+  });
+
+  it('throws when width ranges omit both min and max', () => {
+    const prefab = MediaQueryTokenPrefab.create(['queries', 'empty']);
+    expect(() => prefab.withWidthRange({})).toThrowError(TypeError);
+    expect(() => MediaQueryTokenPrefab.forWidthRange(['queries', 'missing'], {})).toThrowError(
+      TypeError,
+    );
+  });
+});

--- a/packages/core/src/prefabs/media-query.ts
+++ b/packages/core/src/prefabs/media-query.ts
@@ -1,0 +1,337 @@
+import {
+  TokenPrefab,
+  createInitialState,
+  normaliseTokenPath,
+  type TokenPathInput,
+} from './token-prefab.js';
+import type { TokenPath } from '../tokens/index.js';
+
+export type MediaConstraintComparison = 'min' | 'max' | 'exact';
+
+export interface MediaQueryConstraintInput {
+  readonly feature: string;
+  readonly value?: string | number;
+  readonly unit?: string;
+  readonly comparison?: MediaConstraintComparison;
+}
+
+export interface MediaQueryConstraint {
+  readonly feature: string;
+  readonly value?: string | number;
+  readonly unit?: string;
+  readonly comparison: MediaConstraintComparison;
+}
+
+export interface MediaQueryOptions {
+  readonly mediaType?: string;
+  readonly constraints?: Iterable<MediaQueryConstraintInput>;
+}
+
+export interface MediaQueryValue {
+  readonly mediaType?: string;
+  readonly constraints: readonly MediaQueryConstraint[];
+  readonly query: string;
+}
+
+export interface WidthRangeOptions {
+  readonly min?: number;
+  readonly max?: number;
+  readonly unit?: string;
+}
+
+type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+
+export class MediaQueryTokenPrefab extends TokenPrefab<MediaQueryValue, MediaQueryTokenPrefab> {
+  static create(path: TokenPathInput, options: MediaQueryOptions = {}): MediaQueryTokenPrefab {
+    const tokenPath = normaliseTokenPath(path);
+    const value = normaliseMediaQueryValue(options);
+    return new MediaQueryTokenPrefab(tokenPath, createInitialState(value));
+  }
+
+  static forWidthRange(
+    path: TokenPathInput,
+    options: WidthRangeOptions & Omit<MediaQueryOptions, 'constraints'> = {},
+  ): MediaQueryTokenPrefab {
+    const constraints: MediaQueryConstraintInput[] = [];
+    if (options.min !== undefined) {
+      constraints.push({
+        feature: 'width',
+        comparison: 'min',
+        value: options.min,
+        unit: options.unit ?? 'px',
+      });
+    }
+    if (options.max !== undefined) {
+      constraints.push({
+        feature: 'width',
+        comparison: 'max',
+        value: options.max,
+        unit: options.unit ?? 'px',
+      });
+    }
+
+    if (constraints.length === 0) {
+      throw new TypeError('Width range prefabs require at least a min or max value.');
+    }
+
+    const createOptions: Mutable<Partial<MediaQueryOptions>> = {};
+    createOptions.constraints = constraints;
+
+    if (options.mediaType !== undefined) {
+      createOptions.mediaType = options.mediaType;
+    }
+
+    return MediaQueryTokenPrefab.create(path, createOptions as MediaQueryOptions);
+  }
+
+  private constructor(
+    path: TokenPath,
+    state: ReturnType<typeof createInitialState<MediaQueryValue>>,
+  ) {
+    super('media-query', path, state);
+  }
+
+  protected create(
+    path: TokenPath,
+    state: ReturnType<typeof createInitialState<MediaQueryValue>>,
+  ): MediaQueryTokenPrefab {
+    return new MediaQueryTokenPrefab(path, state);
+  }
+
+  get value(): MediaQueryValue {
+    return this.state.value;
+  }
+
+  withMediaType(mediaType?: string): MediaQueryTokenPrefab {
+    if (mediaType === undefined) {
+      return this.updateValue((current) =>
+        rebuildMediaQueryValue(current, {
+          clearMediaType: true,
+        }),
+      );
+    }
+
+    return this.updateValue((current) =>
+      rebuildMediaQueryValue(current, {
+        mediaType: normaliseMediaType(mediaType),
+      }),
+    );
+  }
+
+  withConstraints(constraints: Iterable<MediaQueryConstraintInput>): MediaQueryTokenPrefab {
+    return this.updateValue((current) =>
+      rebuildMediaQueryValue(current, {
+        constraints: normaliseConstraints(constraints),
+      }),
+    );
+  }
+
+  addConstraint(constraint: MediaQueryConstraintInput): MediaQueryTokenPrefab {
+    const combined = [...this.state.value.constraints, normaliseConstraint(constraint)];
+    return this.withConstraints(combined);
+  }
+
+  withWidthRange(options: WidthRangeOptions): MediaQueryTokenPrefab {
+    const constraints: MediaQueryConstraintInput[] = [];
+    const unit = options.unit ?? 'px';
+
+    if (options.min !== undefined) {
+      constraints.push({ feature: 'width', comparison: 'min', value: options.min, unit });
+    }
+
+    if (options.max !== undefined) {
+      constraints.push({ feature: 'width', comparison: 'max', value: options.max, unit });
+    }
+
+    if (constraints.length === 0) {
+      throw new TypeError('Width ranges require at least a min or max value.');
+    }
+
+    const existing = this.state.value.constraints.filter(
+      (constraint) => constraint.feature !== 'width',
+    );
+    return this.withConstraints([...existing, ...constraints]);
+  }
+}
+
+export const MediaQuery = {
+  create: MediaQueryTokenPrefab.create,
+  forWidthRange: MediaQueryTokenPrefab.forWidthRange,
+};
+
+interface MediaQueryOverrides {
+  readonly mediaType?: string;
+  readonly constraints?: readonly MediaQueryConstraint[];
+  readonly clearMediaType?: boolean;
+}
+
+/**
+ * Validates whether a candidate media feature name conforms to CSS naming conventions.
+ *
+ * @param feature - The feature string to validate.
+ * @returns `true` when the name is syntactically valid.
+ */
+export function isValidMediaFeatureName(feature: string): boolean {
+  return /^[a-z][a-z0-9-]*$/iu.test(feature.trim());
+}
+
+function normaliseMediaQueryValue(options: MediaQueryOptions): MediaQueryValue {
+  const mediaType =
+    options.mediaType === undefined ? undefined : normaliseMediaType(options.mediaType);
+  const constraints = normaliseConstraints(options.constraints ?? []);
+  const query = buildMediaQuery(mediaType, constraints);
+
+  const result: Mutable<MediaQueryValue> = {
+    constraints,
+    query,
+  };
+
+  if (mediaType !== undefined) {
+    result.mediaType = mediaType;
+  }
+
+  return result;
+}
+
+function rebuildMediaQueryValue(
+  value: MediaQueryValue,
+  overrides: MediaQueryOverrides,
+): MediaQueryValue {
+  let mediaType = value.mediaType;
+  if (overrides.clearMediaType === true) {
+    mediaType = undefined;
+  } else if (overrides.mediaType !== undefined) {
+    mediaType = normaliseMediaType(overrides.mediaType);
+  }
+
+  const constraints = overrides.constraints ?? value.constraints;
+  const query = buildMediaQuery(mediaType, constraints);
+
+  const result: Mutable<MediaQueryValue> = {
+    constraints,
+    query,
+  };
+
+  if (mediaType !== undefined) {
+    result.mediaType = mediaType;
+  }
+
+  return result;
+}
+
+function normaliseMediaType(mediaType: string): string {
+  const trimmed = mediaType.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Media types cannot be empty.');
+  }
+  return trimmed;
+}
+
+function normaliseConstraints(
+  constraints: Iterable<MediaQueryConstraintInput>,
+): readonly MediaQueryConstraint[] {
+  const result: MediaQueryConstraint[] = [];
+  for (const constraint of constraints) {
+    result.push(normaliseConstraint(constraint));
+  }
+  return result;
+}
+
+function normaliseConstraint(constraint: MediaQueryConstraintInput): MediaQueryConstraint {
+  const feature = normaliseFeature(constraint.feature);
+  const comparison = constraint.comparison ?? 'exact';
+
+  if (comparison !== 'exact' && comparison !== 'min' && comparison !== 'max') {
+    throw new TypeError(`Unsupported media constraint comparison: ${comparison}`);
+  }
+
+  const value =
+    constraint.value === undefined ? undefined : normaliseConstraintValue(constraint.value);
+  const unit = constraint.unit === undefined ? undefined : normaliseUnit(constraint.unit);
+
+  if ((comparison === 'min' || comparison === 'max') && value === undefined) {
+    throw new TypeError(`${comparison}-constraints require a value.`);
+  }
+
+  const result: Mutable<MediaQueryConstraint> = {
+    feature,
+    comparison,
+  };
+
+  if (value !== undefined) {
+    result.value = value;
+  }
+
+  if (unit !== undefined) {
+    result.unit = unit;
+  }
+
+  return result;
+}
+
+function normaliseFeature(feature: string): string {
+  const trimmed = feature.trim();
+  if (!isValidMediaFeatureName(trimmed)) {
+    throw new TypeError(`Invalid media feature name: ${feature}`);
+  }
+  return trimmed.toLowerCase();
+}
+
+function normaliseConstraintValue(value: string | number): string | number {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new TypeError('Media constraint numbers must be finite.');
+    }
+    return value;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Media constraint values cannot be empty.');
+  }
+  return trimmed;
+}
+
+function normaliseUnit(unit: string): string {
+  const trimmed = unit.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Media constraint units cannot be empty.');
+  }
+  return trimmed;
+}
+
+function buildMediaQuery(
+  mediaType: string | undefined,
+  constraints: readonly MediaQueryConstraint[],
+): string {
+  const type = mediaType ?? 'all';
+  if (constraints.length === 0) {
+    return type;
+  }
+
+  const parts = constraints.map((constraint) => formatConstraint(constraint));
+  return `${type} and ${parts.join(' and ')}`;
+}
+
+function formatConstraint(constraint: MediaQueryConstraint): string {
+  const { feature, comparison, value, unit } = constraint;
+  if (comparison === 'exact') {
+    if (value === undefined) {
+      return `(${feature})`;
+    }
+    return `(${feature}: ${formatConstraintValue(value, unit)})`;
+  }
+
+  if (value === undefined) {
+    throw new TypeError(`${comparison}-constraints require a value.`);
+  }
+
+  return `(${comparison}-${feature}: ${formatConstraintValue(value, unit)})`;
+}
+
+function formatConstraintValue(value: string | number, unit: string | undefined): string {
+  if (typeof value === 'number') {
+    return `${value}${unit ?? ''}`;
+  }
+  return unit ? `${value}${unit}` : value;
+}

--- a/packages/core/src/prefabs/panel.spec.ts
+++ b/packages/core/src/prefabs/panel.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { PanelTokenPrefab } from './panel.js';
+
+describe('PanelTokenPrefab', () => {
+  it('normalises panel layers and tokens', () => {
+    const prefab = PanelTokenPrefab.create(['components', 'card'], {
+      panelType: 'surface',
+      layers: [
+        { kind: 'fill', token: '  color.surface ' },
+        { kind: 'shadow', token: ' elevation.low ', opacity: 0.5 },
+      ],
+    });
+
+    expect(prefab.value.panelType).toBe('surface');
+    expect(prefab.value.layers).toEqual([
+      { kind: 'fill', token: 'color.surface' },
+      { kind: 'shadow', token: 'elevation.low', opacity: 0.5 },
+    ]);
+  });
+
+  it('applies padding and radius helpers', () => {
+    const prefab = PanelTokenPrefab.create(['components', 'sheet']);
+    const updated = prefab.withPadding([8, 16]).withRadius([4, 4, 8, 8]);
+
+    expect(updated.value.padding).toEqual({ top: 8, right: 16, bottom: 8, left: 16 });
+    expect(updated.value.radius).toEqual({ top: 4, right: 4, bottom: 8, left: 8 });
+
+    const cleared = updated.withPadding().withRadius();
+    expect(cleared.value.padding).toBeUndefined();
+    expect(cleared.value.radius).toBeUndefined();
+  });
+
+  it('throws for unsupported layer kinds', () => {
+    expect(() =>
+      PanelTokenPrefab.create(['components', 'bad'], {
+        layers: [{ kind: 'texture' as never, token: 'pattern' }],
+      }),
+    ).toThrowError(TypeError);
+  });
+});

--- a/packages/core/src/prefabs/panel.ts
+++ b/packages/core/src/prefabs/panel.ts
@@ -1,0 +1,338 @@
+import {
+  TokenPrefab,
+  createInitialState,
+  normaliseTokenPath,
+  type TokenPathInput,
+} from './token-prefab.js';
+import type { TokenPath } from '../tokens/index.js';
+
+export type PanelLayerKind = 'fill' | 'stroke' | 'shadow';
+
+export interface PanelLayer {
+  readonly kind: PanelLayerKind;
+  readonly token: string;
+  readonly opacity?: number;
+  readonly width?: number;
+}
+
+export type PanelLayerInput = PanelLayer;
+
+export interface PanelSpace {
+  readonly top: number;
+  readonly right: number;
+  readonly bottom: number;
+  readonly left: number;
+}
+
+export type PanelSpaceInput =
+  | number
+  | readonly [number, number]
+  | readonly [number, number, number]
+  | readonly [number, number, number, number]
+  | PanelSpace;
+
+export interface PanelOptions {
+  readonly panelType?: string;
+  readonly layers?: Iterable<PanelLayerInput>;
+  readonly radius?: PanelSpaceInput;
+  readonly padding?: PanelSpaceInput;
+}
+
+export interface PanelValue {
+  readonly panelType?: string;
+  readonly layers: readonly PanelLayer[];
+  readonly radius?: PanelSpace;
+  readonly padding?: PanelSpace;
+}
+
+type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+
+export class PanelTokenPrefab extends TokenPrefab<PanelValue, PanelTokenPrefab> {
+  static create(path: TokenPathInput, options: PanelOptions = {}): PanelTokenPrefab {
+    const tokenPath = normaliseTokenPath(path);
+    const value = normalisePanelValue(options);
+    return new PanelTokenPrefab(tokenPath, createInitialState(value));
+  }
+
+  private constructor(path: TokenPath, state: ReturnType<typeof createInitialState<PanelValue>>) {
+    super('panel', path, state);
+  }
+
+  protected create(
+    path: TokenPath,
+    state: ReturnType<typeof createInitialState<PanelValue>>,
+  ): PanelTokenPrefab {
+    return new PanelTokenPrefab(path, state);
+  }
+
+  get value(): PanelValue {
+    return this.state.value;
+  }
+
+  withPanelType(panelType?: string): PanelTokenPrefab {
+    if (panelType === undefined) {
+      return this.updateValue((current) =>
+        rebuildPanelValue(current, {
+          clearPanelType: true,
+        }),
+      );
+    }
+
+    return this.updateValue((current) =>
+      rebuildPanelValue(current, {
+        panelType: normalisePanelType(panelType),
+      }),
+    );
+  }
+
+  withLayers(layers: Iterable<PanelLayerInput>): PanelTokenPrefab {
+    return this.updateValue((current) =>
+      rebuildPanelValue(current, {
+        layers: normalisePanelLayers(layers),
+      }),
+    );
+  }
+
+  addLayer(layer: PanelLayerInput): PanelTokenPrefab {
+    const combined = [...this.state.value.layers, layer];
+    return this.withLayers(combined);
+  }
+
+  withRadius(radius?: PanelSpaceInput): PanelTokenPrefab {
+    if (radius === undefined) {
+      return this.updateValue((current) =>
+        rebuildPanelValue(current, {
+          clearRadius: true,
+        }),
+      );
+    }
+
+    return this.updateValue((current) =>
+      rebuildPanelValue(current, {
+        radius: normalisePanelSpace(radius, 'radius'),
+      }),
+    );
+  }
+
+  withPadding(padding?: PanelSpaceInput): PanelTokenPrefab {
+    if (padding === undefined) {
+      return this.updateValue((current) =>
+        rebuildPanelValue(current, {
+          clearPadding: true,
+        }),
+      );
+    }
+
+    return this.updateValue((current) =>
+      rebuildPanelValue(current, {
+        padding: normalisePanelSpace(padding, 'padding'),
+      }),
+    );
+  }
+}
+
+export const Panel = {
+  create: PanelTokenPrefab.create,
+};
+
+interface PanelOverrides {
+  readonly panelType?: string;
+  readonly clearPanelType?: boolean;
+  readonly layers?: readonly PanelLayer[];
+  readonly radius?: PanelSpace;
+  readonly clearRadius?: boolean;
+  readonly padding?: PanelSpace;
+  readonly clearPadding?: boolean;
+}
+
+function normalisePanelValue(options: PanelOptions): PanelValue {
+  const layers = normalisePanelLayers(options.layers ?? []);
+
+  const result: Mutable<PanelValue> = {
+    layers,
+  };
+
+  if (options.panelType !== undefined) {
+    result.panelType = normalisePanelType(options.panelType);
+  }
+
+  if (options.radius !== undefined) {
+    result.radius = normalisePanelSpace(options.radius, 'radius');
+  }
+
+  if (options.padding !== undefined) {
+    result.padding = normalisePanelSpace(options.padding, 'padding');
+  }
+
+  return result;
+}
+
+function rebuildPanelValue(value: PanelValue, overrides: PanelOverrides): PanelValue {
+  let panelType = value.panelType;
+  if (overrides.clearPanelType === true) {
+    panelType = undefined;
+  } else if (overrides.panelType !== undefined) {
+    panelType = normalisePanelType(overrides.panelType);
+  }
+
+  const layers = normalisePanelLayers(overrides.layers ?? value.layers);
+
+  let radius = value.radius;
+  if (overrides.clearRadius === true) {
+    radius = undefined;
+  } else if (overrides.radius !== undefined) {
+    radius = normalisePanelSpace(overrides.radius, 'radius');
+  }
+
+  let padding = value.padding;
+  if (overrides.clearPadding === true) {
+    padding = undefined;
+  } else if (overrides.padding !== undefined) {
+    padding = normalisePanelSpace(overrides.padding, 'padding');
+  }
+
+  const result: Mutable<PanelValue> = {
+    layers,
+  };
+
+  if (panelType !== undefined) {
+    result.panelType = panelType;
+  }
+
+  if (radius !== undefined) {
+    result.radius = radius;
+  }
+
+  if (padding !== undefined) {
+    result.padding = padding;
+  }
+
+  return result;
+}
+
+function normalisePanelType(panelType: string): string {
+  const trimmed = panelType.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Panel type cannot be empty.');
+  }
+  return trimmed;
+}
+
+function normalisePanelLayers(layers: Iterable<PanelLayerInput>): readonly PanelLayer[] {
+  const result: PanelLayer[] = [];
+  for (const layer of layers) {
+    result.push(normalisePanelLayer(layer));
+  }
+  return result;
+}
+
+function normalisePanelLayer(layer: PanelLayerInput): PanelLayer {
+  const result: Mutable<PanelLayer> = {
+    kind: normaliseLayerKind(layer.kind),
+    token: normaliseLayerToken(layer.token),
+  };
+
+  if (layer.opacity !== undefined) {
+    result.opacity = normaliseOpacity(layer.opacity);
+  }
+
+  if (layer.width !== undefined) {
+    result.width = normaliseLayerWidth(layer.width);
+  }
+
+  return result;
+}
+
+function normaliseLayerKind(kind: PanelLayerKind): PanelLayerKind {
+  if (kind !== 'fill' && kind !== 'stroke' && kind !== 'shadow') {
+    throw new TypeError(`Unsupported panel layer kind: ${kind}`);
+  }
+  return kind;
+}
+
+function normaliseLayerToken(token: string): string {
+  const trimmed = token.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError('Panel layer tokens cannot be empty.');
+  }
+  return trimmed;
+}
+
+function normaliseOpacity(opacity: number): number {
+  if (!Number.isFinite(opacity) || opacity < 0 || opacity > 1) {
+    throw new TypeError('Panel layer opacity must be a finite number between 0 and 1.');
+  }
+  return opacity;
+}
+
+function normaliseLayerWidth(width: number): number {
+  if (!Number.isFinite(width) || width < 0) {
+    throw new TypeError('Panel layer width must be a non-negative finite number.');
+  }
+  return width;
+}
+
+function normalisePanelSpace(input: PanelSpaceInput, label: 'radius' | 'padding'): PanelSpace {
+  if (typeof input === 'number') {
+    return createPanelSpace(input, input, input, input);
+  }
+
+  if (Array.isArray(input)) {
+    if (input.length === 2) {
+      const [vertical, horizontal] = input;
+      return createPanelSpace(vertical, horizontal, vertical, horizontal);
+    }
+
+    if (input.length === 3) {
+      const [top, horizontal, bottom] = input;
+      return createPanelSpace(top, horizontal, bottom, horizontal);
+    }
+
+    if (input.length === 4) {
+      const [top, right, bottom, left] = input;
+      return createPanelSpace(top, right, bottom, left);
+    }
+
+    throw new TypeError(`Panel ${label} arrays must contain 2, 3, or 4 entries.`);
+  }
+
+  if (isPanelSpace(input)) {
+    return createPanelSpace(input.top, input.right, input.bottom, input.left);
+  }
+
+  throw new TypeError(`Unsupported panel ${label} value.`);
+}
+
+function createPanelSpace(top: number, right: number, bottom: number, left: number): PanelSpace {
+  return {
+    top: normaliseSpaceDimension('top', top),
+    right: normaliseSpaceDimension('right', right),
+    bottom: normaliseSpaceDimension('bottom', bottom),
+    left: normaliseSpaceDimension('left', left),
+  } satisfies PanelSpace;
+}
+
+function normaliseSpaceDimension(name: string, value: number): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new TypeError(`Panel ${name} value must be a non-negative finite number.`);
+  }
+  return value;
+}
+
+function isPanelSpace(value: unknown): value is PanelSpace {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    'top' in candidate &&
+    'right' in candidate &&
+    'bottom' in candidate &&
+    'left' in candidate &&
+    typeof candidate['top'] === 'number' &&
+    typeof candidate['right'] === 'number' &&
+    typeof candidate['bottom'] === 'number' &&
+    typeof candidate['left'] === 'number'
+  );
+}


### PR DESCRIPTION
## Summary
- add token prefabs for fonts, images, panels, and media queries with fluent mutation helpers and validation
- cover new prefabs with unit tests and export them through the prefab index
- document the prefab library, update the core package README, and add a changeset entry

## Testing
- pnpm lint
- pnpm lint:markdown
- pnpm build
- pnpm test -- --verbose
- pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68f9713353548328a5869e6bc0d71652