### PR TITLE
feat(build): surface docs.static transform snippets

### DIFF
--- a/.changeset/document-snippets-docs-static.md
+++ b/.changeset/document-snippets-docs-static.md
@@ -1,0 +1,6 @@
+---
+'@dtifx/build': minor
+---
+
+Add SwiftUI, Compose, and CSS code snippets to `docs.static` bundles by mapping supported transform
+outputs into tabbed examples.

--- a/docs/reference/build-formatters.md
+++ b/docs/reference/build-formatters.md
@@ -103,6 +103,24 @@ The bundle requires no build step—host the directory on any static site server
 copies local assets referenced by tokens or transform outputs, the documentation includes inline
 previews for images and download links for other file types.
 
+### Code snippets
+
+`docs.static` can surface language-specific code snippets alongside transform examples. When a token
+includes color transform outputs, the formatter maps them to small SwiftUI, Jetpack Compose, or CSS
+snippets and renders them in an accessible tabbed interface beneath the transform payload. The UI
+falls back gracefully when no snippets are available, so legacy bundles remain compatible.
+
+To enable the snippets bundled with the formatter, ensure your build configuration runs the relevant
+transforms for the tokens you want to showcase:
+
+- `color.toCss` — enables CSS variable snippets derived from the transform metadata.
+- `color.toSwiftUIColor` — generates SwiftUI initializer samples for the token’s color values.
+- `color.toAndroidComposeColor` — emits Jetpack Compose `Color(...)` literals for Android
+  previewers.
+
+You can register custom snippet generators by extending the formatter or by emitting additional
+transforms and mapping them to snippet templates in your own formatter entry.
+
 ### Customisation tips
 
 - Combine the formatter with [`dtifx build watch`](/api/build-workflows#watch) during design audits

--- a/packages/build/src/formatter/definitions/docs/docs-static-formatter.ts
+++ b/packages/build/src/formatter/definitions/docs/docs-static-formatter.ts
@@ -11,11 +11,15 @@ import type { FormatterDefinitionFactory } from '../../formatter-factory.js';
 import type { FormatterDefinition, FileArtifact } from '../../formatter-registry.js';
 import {
   createDocumentationPlan,
+  createAndroidComposeColorSnippets,
+  createCssColorVariableSnippets,
+  createSwiftUiColorSnippets,
   type DocumentationAssetPlan,
   type DocsAsset,
   type DocsAssetKind,
   type DocsDocumentationModel,
   type DocumentationModelOptions,
+  type DocsSnippetGenerator,
 } from './documentation-model.js';
 import {
   createAppScript,
@@ -100,7 +104,8 @@ function createDocsStaticFormatterDefinition(
         return [];
       }
 
-      const plan = createDocumentationPlan(tokens, toModelOptions(options));
+      const snippetGenerators = createDefaultSnippetGenerators();
+      const plan = createDocumentationPlan(tokens, toModelOptions(options, snippetGenerators));
       const {
         artifacts: assetArtifacts,
         assets,
@@ -139,12 +144,23 @@ function createDocsStaticFormatterDefinition(
   } satisfies FormatterDefinition;
 }
 
-function toModelOptions(options: DocsStaticFormatterOptions): DocumentationModelOptions {
-  const base: DocumentationModelOptions = { title: options.title };
+function toModelOptions(
+  options: DocsStaticFormatterOptions,
+  snippets: ReadonlyMap<string, DocsSnippetGenerator>,
+): DocumentationModelOptions {
+  const base: DocumentationModelOptions = { title: options.title, snippetGenerators: snippets };
   if (options.description === undefined) {
     return base;
   }
   return { ...base, description: options.description } satisfies DocumentationModelOptions;
+}
+
+function createDefaultSnippetGenerators(): ReadonlyMap<string, DocsSnippetGenerator> {
+  return new Map<string, DocsSnippetGenerator>([
+    ['color.toCss', createCssColorVariableSnippets],
+    ['color.toSwiftUIColor', createSwiftUiColorSnippets],
+    ['color.toAndroidComposeColor', createAndroidComposeColorSnippets],
+  ]);
 }
 
 async function processAssetPlans(plans: readonly DocumentationAssetPlan[]): Promise<{

--- a/packages/build/src/formatter/definitions/docs/templates/styles.css
+++ b/packages/build/src/formatter/definitions/docs/templates/styles.css
@@ -184,6 +184,65 @@ body {
   line-height: 1.45;
 }
 
+.docs-snippet {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.docs-snippet__tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.docs-snippet__tab {
+  border: 1px solid rgba(15, 23, 42, 0.16);
+  background-color: rgba(15, 23, 42, 0.05);
+  color: inherit;
+  padding: 0.35rem 0.85rem;
+  border-radius: 9999px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.docs-snippet__tab.is-active {
+  background-color: rgba(59, 130, 246, 0.2);
+  border-color: rgba(59, 130, 246, 0.4);
+}
+
+.docs-snippet__tab:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.7);
+  outline-offset: 2px;
+}
+
+.docs-snippet__panels {
+  border-radius: 0.65rem;
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+}
+
+.docs-snippet__pre {
+  margin: 0;
+  padding: 0.85rem;
+  max-height: 340px;
+  overflow: auto;
+  background-color: #0f172a;
+  color: #f8fafc;
+  font-family: 'Fira Code', 'SFMono-Regular', Menlo, Consolas, monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.docs-snippet__code {
+  display: block;
+  white-space: pre;
+}
+
 .docs-asset-list {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- extend the documentation model to collect formatter-provided code snippets and add helpers for CSS, SwiftUI, and Compose outputs
- wire the docs.static formatter to emit snippet metadata and cover it with unit tests
- render accessible snippet tabs in the docs template, document the capability, and record a changeset

## Testing
- CI=1 pnpm lint
- CI=1 pnpm lint:markdown
- CI=1 pnpm build
- CI=1 pnpm test
- CI=1 pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68f971886328832898c5dc44b2147630