### PR TITLE
fix(changesets): prevent peer dependency major bumps

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -22,6 +22,10 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true,
+    "updateInternalDependents": "out-of-range"
+  },
   "privatePackages": {
     "version": true,
     "tag": false

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,9 +56,9 @@
     "@dtifx/extractors": "workspace:*"
   },
   "peerDependencies": {
-    "@dtifx/audit": "workspace:*",
-    "@dtifx/build": "workspace:*",
-    "@dtifx/diff": "workspace:*"
+    "@dtifx/audit": "workspace:^",
+    "@dtifx/build": "workspace:^",
+    "@dtifx/diff": "workspace:^"
   },
   "private": false,
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,16 +163,16 @@ importers:
   packages/cli:
     dependencies:
       '@dtifx/audit':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../audit
       '@dtifx/build':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../build
       '@dtifx/core':
         specifier: workspace:*
         version: link:../core
       '@dtifx/diff':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../diff
       '@dtifx/extractors':
         specifier: workspace:*


### PR DESCRIPTION
## Summary
- add Changesets config to skip major peer dependency bumps unless ranges are out of date
- loosen @dtifx/cli peer dependency ranges to workspace caret versions to align with semver minors
- update the lockfile to reflect the new workspace specifiers

## Testing
- pnpm lint
- pnpm lint:markdown
- pnpm build
- pnpm test *(fails: vitest coverage temp files missing)*
- pnpm format:check *(no output recorded)*
- CI=1 pnpm docs:build *(not run)*

------
https://chatgpt.com/codex/tasks/task_e_68f9ee02561c8328b30501894d1769ea