### PR TITLE
Align package order in docs home and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ telemetry.
 
 | Package                                    | Purpose                                                                 |
 | ------------------------------------------ | ----------------------------------------------------------------------- |
-| [`@dtifx/cli`](packages/cli)               | Unified CLI for extract, diff, build, and audit workflows.              |
-| [`@dtifx/extractors`](packages/extractors) | Connects design providers (starting with Figma) to DTIF token exports.  |
-| [`@dtifx/build`](packages/build)           | Plans token layers, runs transforms, and renders distributable outputs. |
-| [`@dtifx/diff`](packages/diff)             | Calculates DTIF diffs and produces human and machine-friendly reports.  |
 | [`@dtifx/audit`](packages/audit)           | Evaluates policy manifests and surfaces actionable guidance.            |
+| [`@dtifx/build`](packages/build)           | Plans token layers, runs transforms, and renders distributable outputs. |
+| [`@dtifx/cli`](packages/cli)               | Unified CLI for extract, diff, build, and audit workflows.              |
 | [`@dtifx/core`](packages/core)             | Shared runtime primitives used by every package and custom hosts.       |
+| [`@dtifx/diff`](packages/diff)             | Calculates DTIF diffs and produces human and machine-friendly reports.  |
+| [`@dtifx/extractors`](packages/extractors) | Connects design providers (starting with Figma) to DTIF token exports.  |
 
 Review each package README for detailed usage examples and API references.
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -31,11 +31,11 @@ export default defineConfig({
       {
         text: 'Packages',
         items: [
-          { text: '@dtifx/core', link: '/core/' },
-          { text: '@dtifx/build', link: '/build/' },
-          { text: '@dtifx/diff', link: '/diff/' },
-          { text: '@dtifx/cli', link: '/cli/' },
           { text: '@dtifx/audit', link: '/audit/' },
+          { text: '@dtifx/build', link: '/build/' },
+          { text: '@dtifx/cli', link: '/cli/' },
+          { text: '@dtifx/core', link: '/core/' },
+          { text: '@dtifx/diff', link: '/diff/' },
           { text: '@dtifx/extractors', link: '/extractors/' },
         ],
       },

--- a/docs/.vitepress/theme/styles/custom.css
+++ b/docs/.vitepress/theme/styles/custom.css
@@ -203,6 +203,10 @@
   box-shadow: 0 18px 40px -28px rgba(15, 23, 42, 0.45);
 }
 
+.VPHomeFeatures .items {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
 .VPHomeFeatures .icon img {
   display: block;
   width: 48px;
@@ -269,6 +273,10 @@
 
 @media (min-width: 1280px) {
   .dtifx-hubs__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .VPHomeFeatures .items {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,14 +20,14 @@ hero:
       link: /core/
 features:
   - icon:
-      src: /logos/dtifx-core.svg
-      alt: '@dtifx/core logo'
+      src: /logos/dtifx-audit.svg
+      alt: '@dtifx/audit logo'
     iconBackground: 'rgba(32, 41, 72, 0.06)'
-    title: '@dtifx/core'
+    title: '@dtifx/audit'
     details: |
-      Shared diagnostics, telemetry factories, configuration loaders, and runtime primitives for the suite.
-    link: /core/
-    linkText: Read the runtime guide
+      Evaluate governance policies, generate evidence, and automate compliance across DTIFx workflows.
+    link: /audit/
+    linkText: Visit the audit hub
   - icon:
       src: /logos/dtifx-build.svg
       alt: '@dtifx/build logo'
@@ -38,15 +38,6 @@ features:
     link: /build/
     linkText: Browse the build docs
   - icon:
-      src: /logos/dtifx-diff.svg
-      alt: '@dtifx/diff logo'
-    iconBackground: 'rgba(32, 41, 72, 0.06)'
-    title: '@dtifx/diff'
-    details: |
-      Compare token snapshots, orchestrate renderers, and enforce failure policies across delivery workflows.
-    link: /diff/
-    linkText: Review diff strategies
-  - icon:
       src: /logos/dtifx-cli.svg
       alt: '@dtifx/cli logo'
     iconBackground: 'rgba(32, 41, 72, 0.06)'
@@ -55,6 +46,24 @@ features:
       Operate the toolkit through an ergonomic CLI kernel with shared flags, IO adapters, and module runners.
     link: /cli/
     linkText: Open the CLI reference
+  - icon:
+      src: /logos/dtifx-core.svg
+      alt: '@dtifx/core logo'
+    iconBackground: 'rgba(32, 41, 72, 0.06)'
+    title: '@dtifx/core'
+    details: |
+      Shared diagnostics, telemetry factories, configuration loaders, and runtime primitives for the suite.
+    link: /core/
+    linkText: Read the runtime guide
+  - icon:
+      src: /logos/dtifx-diff.svg
+      alt: '@dtifx/diff logo'
+    iconBackground: 'rgba(32, 41, 72, 0.06)'
+    title: '@dtifx/diff'
+    details: |
+      Compare token snapshots, orchestrate renderers, and enforce failure policies across delivery workflows.
+    link: /diff/
+    linkText: Review diff strategies
   - icon:
       src: /logos/dtifx-extractors.svg
       alt: '@dtifx/extractors logo'
@@ -65,19 +74,8 @@ features:
       documents ready for downstream automation.
     link: /extractors/
     linkText: Explore extractor docs
-  - icon:
-      src: /logos/dtifx-audit.svg
-      alt: '@dtifx/audit logo'
-    iconBackground: 'rgba(32, 41, 72, 0.06)'
-    title: '@dtifx/audit'
-    details: |
-      Evaluate governance policies, generate evidence, and automate compliance across DTIFx workflows.
-    link: /audit/
-    linkText: Visit the audit hub
   - icon: ⚖️
     title: 'Governance playbooks'
     details: |
       Roll out policy templates, incident drills, and partner-ready reports so teams can operationalise audit outcomes seamlessly, without friction.
-    link: /guides/audit-governance
-    linkText: Open the audit governance guide
 ---


### PR DESCRIPTION
## Summary
- reorder the VitePress home feature cards so package hubs are listed alphabetically and drop the governance playbook link
- adjust the Packages navigation group and README package table to match the alphabetical ordering
- constrain the homepage feature grid to three columns for consistent card sizing

## Testing
- pnpm lint
- pnpm lint:markdown
- NX_CI=1 pnpm build
- NX_CI=1 NX_OUTPUT_STYLE=stream pnpm test -- --parallel=1 *(tasks succeeded from cache; command did not exit cleanly so it was stopped after verifying the success summary)*
- pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68fa3945e2388328a1b8b839261de5ea