### PR TITLE
Ensure diff compare creates output directories

### DIFF
--- a/.changeset/ensure-diff-output-dir.md
+++ b/.changeset/ensure-diff-output-dir.md
@@ -1,0 +1,5 @@
+---
+'@dtifx/cli': patch
+---
+
+ensure diff compare reports create parent directories when writing to disk

--- a/packages/cli/src/tools/diff/compare-command-runner.ts
+++ b/packages/cli/src/tools/diff/compare-command-runner.ts
@@ -1,4 +1,5 @@
-import { readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
 import process from 'node:process';
 
 import type * as DiffModuleExports from '@dtifx/diff';
@@ -131,6 +132,7 @@ export const executeDiffCompareCommand = async ({
   const output = `${renderedReport}\n`;
 
   if (options.outputPath) {
+    await mkdir(path.dirname(options.outputPath), { recursive: true });
     await writeFile(options.outputPath, output, 'utf8');
   } else {
     io.writeOut(output);

--- a/packages/cli/tests/diff-command.integration.spec.ts
+++ b/packages/cli/tests/diff-command.integration.spec.ts
@@ -1,0 +1,45 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import { describe, expect, test } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const cliProjectRoot = path.resolve(__dirname, '..');
+const diffStubRunner = path.resolve(__dirname, 'helpers', 'run-diff-cli-with-stub.ts');
+
+const runDiffCli = async (args: string[]) => {
+  return execFileAsync('pnpm', ['exec', 'tsx', diffStubRunner, ...args], {
+    cwd: cliProjectRoot,
+    env: process.env,
+    maxBuffer: 5 * 1024 * 1024,
+  });
+};
+
+describe('dtifx diff compare', () => {
+  test('writes diff output to nested directories when requested', async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), 'dtifx-cli-diff-'));
+
+    try {
+      const previousPath = path.join(workspace, 'previous.json');
+      const nextPath = path.join(workspace, 'next.json');
+      await writeFile(previousPath, JSON.stringify({ tokens: { alpha: { $value: 'a' } } }), 'utf8');
+      await writeFile(nextPath, JSON.stringify({ tokens: { alpha: { $value: 'b' } } }), 'utf8');
+
+      const outputPath = path.join(workspace, 'artifacts', 'reports', 'diff-output.txt');
+
+      await runDiffCli(['diff', 'compare', previousPath, nextPath, '--output', outputPath]);
+
+      const contents = await readFile(outputPath, 'utf8');
+      expect(contents).toBe('stub-report\n');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  }, 120_000);
+});

--- a/packages/cli/tests/fixtures/diff/mock-diff-module.ts
+++ b/packages/cli/tests/fixtures/diff/mock-diff-module.ts
@@ -1,0 +1,29 @@
+export interface MockRunContext {
+  readonly sources: unknown;
+  readonly startedAt: Date;
+  readonly durationMs: number;
+}
+
+export const supportsCliHyperlinks = (): boolean => false;
+
+export const createSessionTokenSourcePort = (_sources: unknown, _options: unknown): object => {
+  return {};
+};
+
+export const runDiffSession = async (): Promise<{
+  readonly filteredDiff: string;
+  readonly failure: { readonly shouldFail: boolean };
+}> => {
+  return {
+    filteredDiff: 'mock-diff',
+    failure: { shouldFail: false },
+  };
+};
+
+export const createRunContext = (input: MockRunContext): MockRunContext => {
+  return input;
+};
+
+export const renderReport = async (): Promise<string> => {
+  return 'stub-report';
+};

--- a/packages/cli/tests/helpers/run-diff-cli-with-stub.ts
+++ b/packages/cli/tests/helpers/run-diff-cli-with-stub.ts
@@ -1,0 +1,15 @@
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { __testing } from '../../src/tools/diff/compare-command-runner.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const stubModuleUrl = pathToFileURL(
+  path.resolve(__dirname, '../fixtures/diff/mock-diff-module.ts'),
+).href;
+
+__testing.setDiffModuleImporter(() => import(stubModuleUrl));
+
+await import('../../src/bin.ts');


### PR DESCRIPTION
## Summary
- ensure `dtifx diff compare` creates the parent directory before writing reports
- add a CLI integration test that runs the diff command with a stubbed diff module and writes to a nested output path
- document the change with a patch changeset for `@dtifx/cli`

## Testing
- CI=1 pnpm lint
- pnpm lint:markdown
- pnpm build
- CI=1 pnpm test
- CI=1 pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68faaea7abc883288beb02ed7f6f8207