### PR TITLE
Fix extractors CLI smoke test packaging

### DIFF
--- a/.changeset/fix-extractors-cli-smoke.md
+++ b/.changeset/fix-extractors-cli-smoke.md
@@ -1,0 +1,5 @@
+---
+'@dtifx/extractors': patch
+---
+
+ensure cli smoke test installs local peer packages

--- a/packages/extractors/scripts/cli-smoke.sh
+++ b/packages/extractors/scripts/cli-smoke.sh
@@ -30,6 +30,21 @@ CLI_PKG_PATH=""
 CLI_PKG_CLEANUP_PATH=""
 CORE_PKG_PATH=""
 CORE_PKG_CLEANUP_PATH=""
+BUILD_PKG_PATH=""
+BUILD_PKG_CLEANUP_PATH=""
+DIFF_PKG_PATH=""
+DIFF_PKG_CLEANUP_PATH=""
+AUDIT_PKG_PATH=""
+AUDIT_PKG_CLEANUP_PATH=""
+
+CLI_DEPENDENCIES_BUILT=0
+
+ensure_cli_dependencies_built() {
+  if [[ "${CLI_DEPENDENCIES_BUILT}" -eq 0 ]]; then
+    pnpm exec nx run-many -t build --projects core,cli,build,diff,audit --output-style=static >&2
+    CLI_DEPENDENCIES_BUILT=1
+  fi
+}
 
 if [[ -z "${CLI_PKG:-}" ]]; then
   CLI_PACKAGE_ROOT="${WORKSPACE_ROOT}/packages/cli"
@@ -39,7 +54,7 @@ if [[ -z "${CLI_PKG:-}" ]]; then
   fi
 
   echo "CLI_PKG not provided; building and packing @dtifx/cli" >&2
-  pnpm exec nx run-many -t build --projects core,cli --output-style=static >&2
+  ensure_cli_dependencies_built
 
   # shellcheck source=../../../scripts/lib/package-utils.sh
   source "${WORKSPACE_ROOT}/scripts/lib/package-utils.sh"
@@ -47,6 +62,33 @@ if [[ -z "${CLI_PKG:-}" ]]; then
   CLI_PKG_PATH="$(pack_workspace_package "${CLI_PACKAGE_ROOT}")"
   CLI_PKG="${CLI_PKG_PATH}"
   CLI_PKG_CLEANUP_PATH="${CLI_PKG_PATH}"
+
+  if [[ -z "${BUILD_PKG:-}" ]]; then
+    BUILD_PACKAGE_ROOT="${WORKSPACE_ROOT}/packages/build"
+    if [[ -d "${BUILD_PACKAGE_ROOT}" ]]; then
+      BUILD_PKG_PATH="$(pack_workspace_package "${BUILD_PACKAGE_ROOT}")"
+      BUILD_PKG="${BUILD_PKG_PATH}"
+      BUILD_PKG_CLEANUP_PATH="${BUILD_PKG_PATH}"
+    fi
+  fi
+
+  if [[ -z "${DIFF_PKG:-}" ]]; then
+    DIFF_PACKAGE_ROOT="${WORKSPACE_ROOT}/packages/diff"
+    if [[ -d "${DIFF_PACKAGE_ROOT}" ]]; then
+      DIFF_PKG_PATH="$(pack_workspace_package "${DIFF_PACKAGE_ROOT}")"
+      DIFF_PKG="${DIFF_PKG_PATH}"
+      DIFF_PKG_CLEANUP_PATH="${DIFF_PKG_PATH}"
+    fi
+  fi
+
+  if [[ -z "${AUDIT_PKG:-}" ]]; then
+    AUDIT_PACKAGE_ROOT="${WORKSPACE_ROOT}/packages/audit"
+    if [[ -d "${AUDIT_PACKAGE_ROOT}" ]]; then
+      AUDIT_PKG_PATH="$(pack_workspace_package "${AUDIT_PACKAGE_ROOT}")"
+      AUDIT_PKG="${AUDIT_PKG_PATH}"
+      AUDIT_PKG_CLEANUP_PATH="${AUDIT_PKG_PATH}"
+    fi
+  fi
 
   if [[ -z "${CORE_PKG:-}" ]]; then
     CORE_PACKAGE_ROOT="${WORKSPACE_ROOT}/packages/core"
@@ -61,6 +103,66 @@ else
     CLI_PKG_PATH="${CLI_PKG}"
   else
     CLI_PKG_PATH="${WORKSPACE_ROOT}/${CLI_PKG}"
+  fi
+fi
+
+if [[ -z "${BUILD_PKG:-}" && -z "${BUILD_PKG_PATH}" ]]; then
+  BUILD_PACKAGE_ROOT="${WORKSPACE_ROOT}/packages/build"
+  if [[ -d "${BUILD_PACKAGE_ROOT}" ]]; then
+    ensure_cli_dependencies_built
+    if ! command -v pack_workspace_package >/dev/null 2>&1; then
+      # shellcheck source=../../../scripts/lib/package-utils.sh
+      source "${WORKSPACE_ROOT}/scripts/lib/package-utils.sh"
+    fi
+    BUILD_PKG_PATH="$(pack_workspace_package "${BUILD_PACKAGE_ROOT}")"
+    BUILD_PKG="${BUILD_PKG_PATH}"
+    BUILD_PKG_CLEANUP_PATH="${BUILD_PKG_PATH}"
+  fi
+elif [[ -n "${BUILD_PKG:-}" && -z "${BUILD_PKG_PATH}" ]]; then
+  if [[ "${BUILD_PKG}" = /* ]]; then
+    BUILD_PKG_PATH="${BUILD_PKG}"
+  else
+    BUILD_PKG_PATH="${WORKSPACE_ROOT}/${BUILD_PKG}"
+  fi
+fi
+
+if [[ -z "${DIFF_PKG:-}" && -z "${DIFF_PKG_PATH}" ]]; then
+  DIFF_PACKAGE_ROOT="${WORKSPACE_ROOT}/packages/diff"
+  if [[ -d "${DIFF_PACKAGE_ROOT}" ]]; then
+    ensure_cli_dependencies_built
+    if ! command -v pack_workspace_package >/dev/null 2>&1; then
+      # shellcheck source=../../../scripts/lib/package-utils.sh
+      source "${WORKSPACE_ROOT}/scripts/lib/package-utils.sh"
+    fi
+    DIFF_PKG_PATH="$(pack_workspace_package "${DIFF_PACKAGE_ROOT}")"
+    DIFF_PKG="${DIFF_PKG_PATH}"
+    DIFF_PKG_CLEANUP_PATH="${DIFF_PKG_PATH}"
+  fi
+elif [[ -n "${DIFF_PKG:-}" && -z "${DIFF_PKG_PATH}" ]]; then
+  if [[ "${DIFF_PKG}" = /* ]]; then
+    DIFF_PKG_PATH="${DIFF_PKG}"
+  else
+    DIFF_PKG_PATH="${WORKSPACE_ROOT}/${DIFF_PKG}"
+  fi
+fi
+
+if [[ -z "${AUDIT_PKG:-}" && -z "${AUDIT_PKG_PATH}" ]]; then
+  AUDIT_PACKAGE_ROOT="${WORKSPACE_ROOT}/packages/audit"
+  if [[ -d "${AUDIT_PACKAGE_ROOT}" ]]; then
+    ensure_cli_dependencies_built
+    if ! command -v pack_workspace_package >/dev/null 2>&1; then
+      # shellcheck source=../../../scripts/lib/package-utils.sh
+      source "${WORKSPACE_ROOT}/scripts/lib/package-utils.sh"
+    fi
+    AUDIT_PKG_PATH="$(pack_workspace_package "${AUDIT_PACKAGE_ROOT}")"
+    AUDIT_PKG="${AUDIT_PKG_PATH}"
+    AUDIT_PKG_CLEANUP_PATH="${AUDIT_PKG_PATH}"
+  fi
+elif [[ -n "${AUDIT_PKG:-}" && -z "${AUDIT_PKG_PATH}" ]]; then
+  if [[ "${AUDIT_PKG}" = /* ]]; then
+    AUDIT_PKG_PATH="${AUDIT_PKG}"
+  else
+    AUDIT_PKG_PATH="${WORKSPACE_ROOT}/${AUDIT_PKG}"
   fi
 fi
 
@@ -84,6 +186,21 @@ fi
 
 if [[ ! -f "${CLI_PKG_PATH}" ]]; then
   echo "Resolved CLI_PKG path ${CLI_PKG_PATH} does not exist" >&2
+  exit 1
+fi
+
+if [[ -n "${BUILD_PKG_PATH}" && ! -f "${BUILD_PKG_PATH}" ]]; then
+  echo "Resolved BUILD_PKG path ${BUILD_PKG_PATH} does not exist" >&2
+  exit 1
+fi
+
+if [[ -n "${DIFF_PKG_PATH}" && ! -f "${DIFF_PKG_PATH}" ]]; then
+  echo "Resolved DIFF_PKG path ${DIFF_PKG_PATH} does not exist" >&2
+  exit 1
+fi
+
+if [[ -n "${AUDIT_PKG_PATH}" && ! -f "${AUDIT_PKG_PATH}" ]]; then
+  echo "Resolved AUDIT_PKG path ${AUDIT_PKG_PATH} does not exist" >&2
   exit 1
 fi
 
@@ -119,6 +236,15 @@ cleanup() {
   if [[ -n "${CLI_PKG_CLEANUP_PATH}" ]]; then
     rm -f "${CLI_PKG_CLEANUP_PATH}" 2>/dev/null || true
   fi
+  if [[ -n "${BUILD_PKG_CLEANUP_PATH}" ]]; then
+    rm -f "${BUILD_PKG_CLEANUP_PATH}" 2>/dev/null || true
+  fi
+  if [[ -n "${DIFF_PKG_CLEANUP_PATH}" ]]; then
+    rm -f "${DIFF_PKG_CLEANUP_PATH}" 2>/dev/null || true
+  fi
+  if [[ -n "${AUDIT_PKG_CLEANUP_PATH}" ]]; then
+    rm -f "${AUDIT_PKG_CLEANUP_PATH}" 2>/dev/null || true
+  fi
   if [[ -n "${CORE_PKG_CLEANUP_PATH}" ]]; then
     rm -f "${CORE_PKG_CLEANUP_PATH}" 2>/dev/null || true
   fi
@@ -128,11 +254,11 @@ trap 'cleanup $?' EXIT
 
 pushd "${WORK_DIR}" >/dev/null
 
-node - <<'NODE' "${WORKSPACE_ROOT}" "${PKG_PATH}" "${CLI_PKG_PATH}" "${CORE_PKG_PATH}"
+node - <<'NODE' "${WORKSPACE_ROOT}" "${PKG_PATH}" "${CLI_PKG_PATH}" "${CORE_PKG_PATH}" "${BUILD_PKG_PATH}" "${DIFF_PKG_PATH}" "${AUDIT_PKG_PATH}"
 const fs = require('node:fs');
 const path = require('node:path');
 
-const [workspaceRoot, extractorsPath, cliPath, corePath] = process.argv.slice(2);
+const [workspaceRoot, extractorsPath, cliPath, corePath, buildPath, diffPath, auditPath] = process.argv.slice(2);
 
 const pkg = {
   name: 'dtifx-extractors-cli-smoke',
@@ -177,6 +303,9 @@ const registerPackage = (name, specifier) => {
 registerPackage('@dtifx/extractors', ensureFileSpecifier(extractorsPath));
 registerPackage('@dtifx/cli', ensureFileSpecifier(cliPath));
 registerPackage('@dtifx/core', ensureFileSpecifier(corePath));
+registerPackage('@dtifx/build', ensureFileSpecifier(buildPath));
+registerPackage('@dtifx/diff', ensureFileSpecifier(diffPath));
+registerPackage('@dtifx/audit', ensureFileSpecifier(auditPath));
 
 if (Object.keys(dependencies).length > 0) {
   pkg.dependencies = {


### PR DESCRIPTION
## Summary
- ensure the extractors CLI smoke test packs @dtifx/cli along with its peer packages so local runs have the required tarballs
- wire the temporary manifest to install the additional workspace packages and clean their artifacts after the smoke test

## Testing
- pnpm lint
- pnpm lint:markdown
- pnpm build
- pnpm test
- pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68faba00fbb08328b336f0830e195d79