### PR TITLE
docs: add npm version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![CLI smoke tests status][cli-smoke-badge]][cli-smoke-workflow]\
 [![Documentation build status][docs-badge]][docs-workflow]\
 [![DTIFx website][site-badge]][site-link]\
+[![npm version][npm-badge]][npm-link]\
 [![License: MIT][license-badge]][license-link]
 
 <!-- markdownlint-enable MD033 -->
@@ -26,6 +27,8 @@
 [site-badge]:
   https://img.shields.io/badge/website-dtifx.lapidist.net-1d4ed8?logo=vercel&logoColor=white
 [site-link]: https://dtifx.lapidist.net
+[npm-badge]: https://img.shields.io/npm/v/%40dtifx%2Fcli
+[npm-link]: https://www.npmjs.com/package/@dtifx/cli
 [license-badge]: https://img.shields.io/github/license/bylapidist/dtifx
 [license-link]: LICENSE
 


### PR DESCRIPTION
## Summary
- add an npm version badge for the @dtifx/cli package to the README badge group
- link the badge to the npm package for quick access

## Testing
- pnpm lint
- pnpm lint:markdown
- pnpm build
- pnpm test
- pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68fb85859a3083288152ec5810baf3ee