### PR TITLE
test(diff): expand coverage for filters and formatting

### DIFF
--- a/packages/diff/tests/application/filters.test.ts
+++ b/packages/diff/tests/application/filters.test.ts
@@ -1,0 +1,46 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+
+import { resolveDiffFilter, type DiffFilterOptions } from '../../src/application/filters.js';
+import type { TokenChangeImpact, TokenChangeKind } from '../../src/domain/diff-types.js';
+
+test('resolveDiffFilter returns unapplied when no options are provided', () => {
+  const result = resolveDiffFilter();
+
+  assert.deepEqual(result, { applied: false });
+});
+
+test('resolveDiffFilter ignores empty filter criteria', () => {
+  const options: DiffFilterOptions = {
+    types: ['   '],
+    paths: [''],
+    groups: ['\t'],
+    impacts: [' ' as TokenChangeImpact],
+    kinds: ['' as TokenChangeKind],
+  };
+
+  const result = resolveDiffFilter(options);
+
+  assert.deepEqual(result, { applied: false });
+});
+
+test('resolveDiffFilter returns only sanitised filter properties', () => {
+  const options: DiffFilterOptions = {
+    types: ['color', ''],
+    paths: [' /globals/background '],
+    groups: ['Global', ''],
+    impacts: ['breaking', 'non-breaking', 42 as unknown as TokenChangeImpact],
+    kinds: ['added', 123 as unknown as TokenChangeKind, 'renamed'],
+  };
+
+  const result = resolveDiffFilter(options);
+
+  assert.equal(result.applied, true);
+  assert.deepEqual(result.filter, {
+    types: ['color'],
+    paths: [' /globals/background '],
+    groups: ['Global'],
+    impacts: ['breaking', 'non-breaking'],
+    kinds: ['added', 'renamed'],
+  });
+});

--- a/packages/diff/tests/application/token-loader.test.ts
+++ b/packages/diff/tests/application/token-loader.test.ts
@@ -5,6 +5,7 @@ import { loadTokenSnapshots, TokenSourceLoadError } from '../../src/application/
 import type {
   TokenSourcePort,
   TokenSourceLabel,
+  TokenSourceContext,
 } from '../../src/application/ports/token-source.js';
 import {
   DiagnosticCategories,
@@ -54,4 +55,124 @@ test('loadTokenSnapshots emits diagnostics for each failed snapshot', async () =
       },
     ],
   );
+});
+
+test('loadTokenSnapshots returns snapshots when both loads succeed', async () => {
+  const contexts: Array<unknown> = [];
+  const snapshots = {
+    previous: new Map(),
+    next: new Map(),
+  } as const;
+
+  const tokenSource: TokenSourcePort = {
+    async load(label, context) {
+      contexts.push(context);
+      return snapshots[label];
+    },
+    describe(label) {
+      return `token-source-${label}`;
+    },
+  };
+
+  const result = await loadTokenSnapshots(tokenSource);
+
+  assert.equal(contexts.length, 2);
+  assert.deepEqual(contexts, [undefined, undefined]);
+  assert.strictEqual(result.previous, snapshots.previous);
+  assert.strictEqual(result.next, snapshots.next);
+});
+
+test('loadTokenSnapshots forwards diagnostics context to the token source port', async () => {
+  const contexts: Array<TokenSourceContext | undefined> = [];
+  const diagnostics: DiagnosticsPort = {
+    emit: async () => {
+      /* noop */
+    },
+  };
+
+  const tokenSource: TokenSourcePort = {
+    async load(label, context) {
+      contexts.push(context);
+      return new Map();
+    },
+    describe(label) {
+      return `token-source-${label}`;
+    },
+  };
+
+  await loadTokenSnapshots(tokenSource, { diagnostics });
+
+  assert.equal(contexts.length, 2);
+  for (const context of contexts) {
+    assert.ok(context);
+    assert.strictEqual(context?.diagnostics, diagnostics);
+  }
+});
+
+test('loadTokenSnapshots reports unavailable descriptions when describe throws', async () => {
+  const events: DiagnosticEvent[] = [];
+  const diagnostics: DiagnosticsPort = {
+    emit(event) {
+      events.push(event);
+    },
+  };
+
+  const tokenSource: TokenSourcePort = {
+    async load() {
+      throw new Error('failed to load snapshot');
+    },
+    describe() {
+      throw 'describe failure';
+    },
+  };
+
+  await assert.rejects(
+    () => loadTokenSnapshots(tokenSource, { diagnostics }),
+    (error: unknown) => {
+      assert.ok(error instanceof TokenSourceLoadError);
+      assert.equal(error.failures.length, 2);
+      assert.equal(error.failures[0]?.description, '(unavailable: describe failure)');
+      return true;
+    },
+  );
+  assert.ok(events.length > 0);
+  assert.match(events[0]?.message ?? '', /describe failure/);
+});
+
+test('TokenSourceLoadError summarises failure causes with indentation', () => {
+  const error = new TokenSourceLoadError([
+    {
+      label: 'previous',
+      description: 'source-a',
+      cause: new Error('first line\nsecond line'),
+    },
+    {
+      label: 'next',
+      description: 'source-b',
+      cause: 'string cause\nextra',
+    },
+    {
+      label: 'next',
+      description: 'source-c',
+      cause: 42,
+    },
+  ]);
+
+  assert.equal(
+    error.message,
+    [
+      'Failed to load token sources:',
+      '- previous (source-a): first line',
+      '  second line',
+      '- next (source-b): string cause',
+      '  extra',
+      '- next (source-c): 42',
+    ].join('\n'),
+  );
+});
+
+test('TokenSourceLoadError falls back to a generic message when there are no failures', () => {
+  const error = new TokenSourceLoadError([]);
+
+  assert.equal(error.message, 'Failed to load token sources.');
 });

--- a/packages/diff/tests/reporting/formatting.test.ts
+++ b/packages/diff/tests/reporting/formatting.test.ts
@@ -3,35 +3,187 @@ import { describe, expect, test } from 'vitest';
 import {
   formatColorLabel,
   formatCssColor,
+  formatMaybeUndefined,
+  formatPointer,
+  formatPointerList,
+  formatTokenSourceLocation,
+  formatTokenValueForSummary,
+  formatValue,
+  formatAlpha,
+  formatSignedDimension,
+  formatSignedPercentage,
+  getDimensionComparison,
+  getDimensionPreview,
   getTokenColor,
+  groupEntriesByTokenType,
+  normalizeTokenType,
   type TokenColor,
 } from '../../src/reporting/formatting.js';
-import type { TokenSnapshot } from '../../src/token-set.js';
+import type { TokenPointer, TokenSnapshot, TokenSourceLocation } from '../../src/token-set.js';
+
+const baseSnapshot: Pick<
+  TokenSnapshot,
+  'id' | 'path' | 'extensions' | 'source' | 'references' | 'resolutionPath' | 'appliedAliases'
+> = {
+  id: '#/tokens/example',
+  path: ['tokens', 'example'],
+  extensions: {},
+  source: { uri: 'memory://test', line: 1, column: 1 },
+  references: [],
+  resolutionPath: [],
+  appliedAliases: [],
+};
+
+function createToken(overrides: Partial<TokenSnapshot> = {}): TokenSnapshot {
+  return {
+    ...baseSnapshot,
+    type: 'color',
+    ...overrides,
+  } satisfies TokenSnapshot;
+}
+
+describe('formatting primitives', () => {
+  test('formatValue returns quoted strings and inspects objects', () => {
+    expect(formatValue('plain')).toBe('"plain"');
+    expect(formatValue({ foo: 1, bar: 'baz' })).toBe("{ bar: 'baz', foo: 1 }");
+  });
+
+  test('formatMaybeUndefined and formatPointer format missing values', () => {
+    expect(formatMaybeUndefined('value')).toBe('value');
+    let missingValue: string | undefined;
+    expect(formatMaybeUndefined(missingValue)).toBe('undefined');
+
+    expect(formatPointer('/design/tokens')).toBe('"/design/tokens"');
+    let missingPointer: string | undefined;
+    expect(formatPointer(missingPointer)).toBe('undefined');
+  });
+
+  test('formatTokenValueForSummary prefers values, then refs, then falls back', () => {
+    expect(formatTokenValueForSummary(createToken({ value: 'primary' }))).toBe("'primary'");
+    expect(formatTokenValueForSummary(createToken({ value: { foo: 1 } }))).toBe('{ foo: 1 }');
+    const summaryWithRef = formatTokenValueForSummary(createToken({ ref: '#/typography/body' }));
+    expect(summaryWithRef).toBe('ref "#/typography/body"');
+    const summaryWithoutValue = formatTokenValueForSummary(createToken());
+    expect(summaryWithoutValue).toBe('undefined');
+  });
+
+  test('formatPointerList renders pointer arrays', () => {
+    const pointers: TokenPointer[] = [
+      { uri: 'file:///tokens.json', pointer: '#/color/base' },
+      { uri: 'memory://inline', pointer: '#/color/alt' },
+    ];
+
+    expect(formatPointerList(pointers)).toBe(
+      "[{ uri: 'file:///tokens.json', pointer: '#/color/base' }, { uri: 'memory://inline', pointer: '#/color/alt' }]",
+    );
+    expect(formatPointerList([])).toBe('[]');
+  });
+
+  test('formatTokenSourceLocation normalises paths and URIs', () => {
+    const noUri: TokenSourceLocation = { uri: '' as string, line: 5, column: 7 };
+    const fileUri: TokenSourceLocation = {
+      uri: 'file:///Users/example/tokens.json',
+      line: 10,
+      column: 2,
+    };
+    const remoteUri: TokenSourceLocation = {
+      uri: 'https://example.com/tokens.json',
+      line: 3,
+      column: 4,
+    };
+    const invalidUri: TokenSourceLocation = { uri: 'file://%zz', line: 1, column: 2 };
+
+    expect(formatTokenSourceLocation(noUri)).toBe('5:7');
+    expect(formatTokenSourceLocation(fileUri)).toBe('/Users/example/tokens.json:10:2');
+    expect(formatTokenSourceLocation(remoteUri)).toBe('https://example.com/tokens.json:3:4');
+    expect(formatTokenSourceLocation(invalidUri)).toBe('%zz:1:2');
+  });
+});
+
+describe('dimension helpers', () => {
+  test('getDimensionPreview extracts values from supported tokens', () => {
+    const preview = getDimensionPreview(createToken({ type: 'dimension', value: '12px' }));
+
+    expect(preview).toEqual({
+      value: 12,
+      unit: 'px',
+      label: '12px',
+      dimensionType: 'length',
+    });
+
+    expect(getDimensionPreview(createToken({ type: 'color', value: '12px' }))).toBeUndefined();
+    expect(getDimensionPreview(createToken({ type: 'dimension' }))).toBeUndefined();
+  });
+
+  test('getDimensionComparison derives deltas and percent changes for matching previews', () => {
+    const previous = createToken({ type: 'dimension', value: '10px' });
+    const next = createToken({ type: 'dimension', value: '15px' });
+    const mismatch = createToken({ type: 'dimension', value: '1rem' });
+
+    expect(getDimensionComparison(previous, mismatch)).toBeUndefined();
+
+    const comparison = getDimensionComparison(previous, next);
+    expect(comparison).toEqual({
+      previous: { value: 10, unit: 'px', label: '10px', dimensionType: 'length' },
+      next: { value: 15, unit: 'px', label: '15px', dimensionType: 'length' },
+      delta: 5,
+      unit: 'px',
+      percentChange: 50,
+    });
+
+    const zeroBaseline = getDimensionComparison(
+      createToken({ type: 'dimension', value: '0px' }),
+      createToken({ type: 'dimension', value: '4px' }),
+    );
+    expect(zeroBaseline).toEqual({
+      previous: { value: 0, unit: 'px', label: '0px', dimensionType: 'length' },
+      next: { value: 4, unit: 'px', label: '4px', dimensionType: 'length' },
+      delta: 4,
+      unit: 'px',
+    });
+  });
+
+  test('formatSignedDimension and formatSignedPercentage include explicit signs', () => {
+    expect(formatSignedDimension(12, 'px')).toBe('+12px');
+    expect(formatSignedDimension(-1.5, 'em')).toBe('-1.5em');
+    expect(formatSignedDimension(0, '')).toBe('+0');
+
+    expect(formatSignedPercentage(0.25)).toBe('+0.25%');
+    expect(formatSignedPercentage(-1)).toBe('-1%');
+  });
+});
+
+describe('token type grouping', () => {
+  test('normalizeTokenType and groupEntriesByTokenType collapse whitespace and undefined values', () => {
+    let missingType: string | undefined;
+    expect(normalizeTokenType(missingType)).toEqual({ key: 'untyped', label: 'untyped' });
+    expect(normalizeTokenType('   ')).toEqual({ key: 'untyped', label: 'untyped' });
+    expect(normalizeTokenType(' Color ')).toEqual({ key: 'color', label: 'color' });
+
+    const entries: Array<{ id: string; type?: string }> = [
+      { id: 'a', type: 'Color' },
+      { id: 'b' },
+      { id: 'c', type: 'color' },
+    ];
+
+    const groups = groupEntriesByTokenType(entries, (entry) => entry.type);
+
+    expect(groups).toEqual([
+      { key: 'color', label: 'color', entries: [entries[0]!, entries[2]!] },
+      { key: 'untyped', label: 'untyped', entries: [entries[1]!] },
+    ]);
+  });
+
+  test('formatAlpha trims trailing zeros', () => {
+    expect(formatAlpha(1)).toBe('1');
+    expect(formatAlpha(0.8)).toBe('0.8');
+    expect(formatAlpha(0.1234)).toBe('0.12');
+  });
+});
 
 describe('getTokenColor', () => {
-  const baseToken: Pick<
-    TokenSnapshot,
-    'id' | 'path' | 'extensions' | 'source' | 'references' | 'resolutionPath' | 'appliedAliases'
-  > = {
-    id: '#/color/test',
-    path: ['color', 'test'],
-    extensions: {},
-    source: { uri: 'memory://test', line: 1, column: 1 },
-    references: [],
-    resolutionPath: [],
-    appliedAliases: [],
-  };
-
-  function createColorToken(value: unknown): TokenSnapshot {
-    return {
-      ...baseToken,
-      type: 'color',
-      value,
-    } satisfies TokenSnapshot;
-  }
-
   test('parses hexadecimal colour strings', () => {
-    const token = createColorToken('#abc123');
+    const token = createToken({ value: '#abc123' });
     const color = getTokenColor(token);
 
     expect(color).toEqual({
@@ -46,10 +198,12 @@ describe('getTokenColor', () => {
   });
 
   test('normalises SRGB components and alpha overrides', () => {
-    const token = createColorToken({
-      colorSpace: 'srgb',
-      components: [0.2, 0.4, 0.6, 0.8],
-      alpha: 0.5,
+    const token = createToken({
+      value: {
+        colorSpace: 'srgb',
+        components: [0.2, 0.4, 0.6, 0.8],
+        alpha: 0.5,
+      },
     });
 
     const color = getTokenColor(token);
@@ -64,6 +218,49 @@ describe('getTokenColor', () => {
 
     expect(formatCssColor(assertTokenColor(color))).toBe('rgba(51, 102, 153, 0.5)');
     expect(formatColorLabel(assertTokenColor(color))).toBe('#336699, alpha 0.5');
+  });
+
+  test('returns undefined for non-colour tokens or missing values', () => {
+    const tokenWithoutType = { ...createToken({ value: '#abc123' }) };
+    delete (tokenWithoutType as { type?: string }).type;
+
+    expect(getTokenColor(tokenWithoutType as TokenSnapshot)).toBeUndefined();
+    expect(getTokenColor(createToken({ type: 'dimension', value: '#abc123' }))).toBeUndefined();
+    expect(getTokenColor(createToken())).toBeUndefined();
+  });
+
+  test('returns undefined for invalid colour representations', () => {
+    expect(getTokenColor(createToken({ value: 'not-a-colour' }))).toBeUndefined();
+    expect(getTokenColor(createToken({ value: { hex: '#zzzzzz' } }))).toBeUndefined();
+    expect(
+      getTokenColor(
+        createToken({ value: { colorSpace: 'display-p3', components: [0.1, 0.2, 0.3] } }),
+      ),
+    ).toBeUndefined();
+    expect(
+      getTokenColor(
+        createToken({ value: { colorSpace: 'srgb', components: ['a', 0.2, 0.3] as unknown[] } }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test('applies override alpha when provided', () => {
+    const token = createToken({
+      value: {
+        colorSpace: 'srgb',
+        components: [16, 32, 64, 128],
+        alpha: 200,
+      },
+    });
+
+    const color = assertTokenColor(getTokenColor(token));
+
+    expect(color.hex).toBe('#102040');
+    expect(color.red).toBe(16);
+    expect(color.green).toBe(32);
+    expect(color.blue).toBe(64);
+    expect(color.alpha).toBeDefined();
+    expect(color.alpha).toBeCloseTo(200 / 255, 3);
   });
 });
 


### PR DESCRIPTION
## Summary
- add unit tests that exercise resolveDiffFilter sanitisation scenarios
- expand token loader coverage for diagnostics context, success path, and error summaries
- broaden formatting utilities tests to cover dimension helpers, grouping, and colour parsing fallbacks

## Testing
- pnpm lint
- pnpm lint:markdown
- pnpm build
- pnpm format:check
- CI=1 pnpm docs:build
- pnpm exec vitest run --config packages/diff/vitest.config.ts --reporter=dot

------
https://chatgpt.com/codex/tasks/task_e_68fbf22593b88328a7069766f6eded9a