### PR TITLE
Add comprehensive reporter coverage for audit package

### DIFF
--- a/packages/audit/src/application/reporting/cli-reporters.spec.ts
+++ b/packages/audit/src/application/reporting/cli-reporters.spec.ts
@@ -1,7 +1,8 @@
 import { createRunContext } from '@dtifx/core';
 import { describe, expect, it, vi } from 'vitest';
 
-import { createAuditReporter, type AuditRunResult } from './cli-reporters.js';
+import { createPolicySnapshot } from '../../testing/policy-test-harness.js';
+import { createAuditReporter, type AuditRunResult, type AuditReporter } from './cli-reporters.js';
 
 class MemoryTarget {
   readonly writes: string[] = [];
@@ -11,8 +12,22 @@ class MemoryTarget {
   }
 }
 
+const baseTimings = {
+  planMs: 300,
+  parseMs: 300,
+  resolveMs: 300,
+  transformMs: 150,
+  formatMs: 100,
+  dependencyMs: 50,
+  totalMs: 1200,
+  auditMs: 200,
+  totalWithAuditMs: 1400,
+} as const;
+
 function createAuditResult(): AuditRunResult {
   const runContext = createRunContext({
+    previous: 'v1.2.2',
+    next: 'v1.2.3',
     startedAt: new Date('2024-01-01T00:00:00.000Z'),
     durationMs: 1200,
   });
@@ -29,17 +44,7 @@ function createAuditResult(): AuditRunResult {
       severity: { error: 0, warning: 0, info: 0 },
       tokenCount: 0,
     },
-    timings: {
-      planMs: 300,
-      parseMs: 300,
-      resolveMs: 300,
-      transformMs: 150,
-      formatMs: 100,
-      dependencyMs: 50,
-      totalMs: 1200,
-      auditMs: 200,
-      totalWithAuditMs: 1400,
-    },
+    timings: { ...baseTimings },
     metadata: { runContext },
   } satisfies AuditRunResult;
 }
@@ -69,10 +74,22 @@ describe('createAuditReporter', () => {
     expect(payload.runContext).toEqual(result.metadata?.runContext);
     expect(logger.log).toHaveBeenCalledWith(
       expect.objectContaining({
+        level: 'info',
         event: 'audit.completed',
         name: 'dtifx-audit',
       }),
     );
+  });
+
+  it('throws when no reporter formats are provided', () => {
+    const logger = { log: vi.fn() } satisfies Parameters<typeof createAuditReporter>[0]['logger'];
+
+    expect(() =>
+      createAuditReporter({
+        format: [] as unknown as AuditReporter['format'],
+        logger,
+      }),
+    ).toThrowError('At least one audit reporter format must be provided.');
   });
 
   it('writes audit failures to stderr with structured logging', () => {
@@ -95,6 +112,7 @@ describe('createAuditReporter', () => {
     expect(stderr.writes.join('')).toContain('Policy plugin failure');
     expect(logger.log).toHaveBeenCalledWith(
       expect.objectContaining({
+        level: 'error',
         event: 'audit.failed',
         name: 'dtifx-audit',
       }),
@@ -192,7 +210,7 @@ describe('createAuditReporter', () => {
     const logger = { log: vi.fn() } satisfies Parameters<typeof createAuditReporter>[0]['logger'];
 
     const reporter = createAuditReporter({
-      format: ['human', 'json'],
+      format: ['human', 'json', 'human'],
       logger,
       stdout,
       stderr,
@@ -216,5 +234,198 @@ describe('createAuditReporter', () => {
     reporter.auditFailure(new Error('composite failure'));
     expect(stderr.writes.join('')).toContain('composite failure');
     expect(logger.log).toHaveBeenCalledTimes(4);
+  });
+
+  it('renders violation context across all formats with severity-aware logging', () => {
+    const stdout = new MemoryTarget();
+    const stderr = new MemoryTarget();
+    const logger = { log: vi.fn() } satisfies Parameters<typeof createAuditReporter>[0]['logger'];
+
+    const reporter = createAuditReporter({
+      format: ['markdown', 'html', 'human', 'markdown'],
+      logger,
+      stdout,
+      stderr,
+      includeTimings: true,
+      cwd: '/workspace/project',
+    });
+
+    const warningSnapshot = createPolicySnapshot({
+      pointer: '#/tokens/primary',
+      sourcePointer: '#/tokens/primary/$value',
+      token: {
+        id: 'tokens/primary',
+        type: 'color',
+        value: { colorSpace: 'srgb', components: [0.1, 0.2, 0.3] },
+        raw: { colorSpace: 'srgb', components: [0.1, 0.2, 0.3] },
+      },
+      provenance: {
+        sourceId: 'tokens',
+        layer: 'brand',
+        layerIndex: 1,
+        uri: 'https://example.com/design/tokens.json',
+        pointerPrefix: '#/tokens',
+      },
+      context: {
+        component: 'button',
+        tags: ['primary', 'cta'],
+        file: { absolute: '/workspace/project/design/tokens.json' },
+        metadata: { deprecated: false },
+        count: 2,
+      },
+    });
+    const errorSnapshot = createPolicySnapshot({
+      pointer: '#/tokens/secondary',
+      sourcePointer: '#/tokens/secondary/$value',
+      token: {
+        id: 'tokens/secondary',
+        type: undefined,
+        value: { colorSpace: 'srgb', components: [0.4, 0.4, 0.4] },
+        raw: { colorSpace: 'srgb', components: [0.4, 0.4, 0.4] },
+      },
+      provenance: {
+        sourceId: 'tokens',
+        layer: 'brand',
+        layerIndex: 1,
+        uri: './relative.json',
+        pointerPrefix: '#/tokens',
+      },
+      context: {
+        file: { absolute: '/workspace/project/design/secondary.json' },
+      },
+    });
+
+    const result: AuditRunResult = {
+      policies: [
+        {
+          name: 'policy.warning',
+          violations: [
+            {
+              policy: 'policy.warning',
+              pointer: warningSnapshot.pointer,
+              snapshot: warningSnapshot,
+              severity: 'warning',
+              message: 'Primary token requires review',
+              details: { reason: 'contrast', threshold: 4.5 },
+            },
+          ],
+        },
+        {
+          name: 'policy.error',
+          violations: [
+            {
+              policy: 'policy.error',
+              pointer: errorSnapshot.pointer,
+              snapshot: errorSnapshot,
+              severity: 'error',
+              message: 'Secondary token failed validation',
+              details: { reason: 'missing-owner' },
+            },
+          ],
+        },
+      ],
+      summary: {
+        policyCount: 2,
+        violationCount: 2,
+        severity: { error: 1, warning: 1, info: 0 },
+        tokenCount: 2,
+      },
+      timings: { ...baseTimings },
+      metadata: {
+        runContext: createRunContext({
+          previous: 'v1.0.0',
+          next: 'v1.1.0',
+          startedAt: '2024-02-02T10:00:00.000Z',
+          durationMs: 2500,
+        }),
+      },
+    } satisfies AuditRunResult;
+
+    reporter.auditSuccess(result);
+
+    const output = stdout.writes.join('');
+    expect(output).toContain('Audit completed with 2 violation(s)');
+    expect(output).toContain('Compared sources: v1.0.0 → v1.1.0');
+    expect(output.replaceAll('\\', '')).toContain('policy.warning (1 violation)');
+    expect(output).toContain('Context: `component`: `button`, `tags`: `primary,cta`');
+    expect(output).toContain('<div class="violation violation-error">');
+    expect(output).toContain('./relative.json#/tokens/secondary');
+    expect(output).toContain('<code>design/tokens.json</code>');
+    expect(output).toContain(
+      'Context</dt><dd><code>file</code>: <code>design/secondary.json</code></dd>',
+    );
+
+    const logLevels = logger.log.mock.calls.map(([entry]) => entry.level);
+    expect(logLevels).toEqual(['error', 'error', 'error']);
+  });
+
+  it('serialises error payloads for JSON failures', () => {
+    const stdout = new MemoryTarget();
+    const stderr = new MemoryTarget();
+    const logger = { log: vi.fn() } satisfies Parameters<typeof createAuditReporter>[0]['logger'];
+
+    const reporter = createAuditReporter({
+      format: 'json',
+      logger,
+      stdout,
+      stderr,
+      cwd: '/workspace',
+    });
+
+    const failure = new Error('Policy failure') as Error & { cause?: unknown };
+    failure.cause = { policy: 'policy.alpha' };
+
+    reporter.auditFailure(failure);
+
+    const payload = JSON.parse(stderr.writes[0]!.trim()) as {
+      readonly error: { readonly message?: string; readonly name?: string };
+    };
+    expect(payload.error).toMatchObject({ name: 'Error', message: 'Policy failure' });
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'error', event: 'audit.failed' }),
+    );
+  });
+
+  it('logs warnings when violations exist without errors', () => {
+    const stdout = new MemoryTarget();
+    const logger = { log: vi.fn() } satisfies Parameters<typeof createAuditReporter>[0]['logger'];
+
+    const reporter = createAuditReporter({
+      format: 'human',
+      logger,
+      stdout,
+      cwd: '/workspace',
+    });
+
+    const snapshot = createPolicySnapshot();
+    const result: AuditRunResult = {
+      policies: [
+        {
+          name: 'policy.warning',
+          violations: [
+            {
+              policy: 'policy.warning',
+              pointer: snapshot.pointer,
+              snapshot,
+              severity: 'warning',
+              message: 'Review required',
+            },
+          ],
+        },
+      ],
+      summary: {
+        policyCount: 1,
+        violationCount: 1,
+        severity: { error: 0, warning: 1, info: 0 },
+        tokenCount: 1,
+      },
+      timings: { ...baseTimings },
+    } satisfies AuditRunResult;
+
+    reporter.auditSuccess(result);
+
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'warn', event: 'audit.completed' }),
+    );
   });
 });

--- a/packages/audit/src/testing/policy-test-harness.spec.ts
+++ b/packages/audit/src/testing/policy-test-harness.spec.ts
@@ -43,4 +43,25 @@ describe('createPolicySnapshot', () => {
     expect(snapshot.token.id).toBe('custom/token');
     expect(snapshot.token.type).toBe('dimension');
   });
+
+  it('retains metadata, resolution, and context overrides', () => {
+    const metadata = {
+      extensions: { 'example.extension': { owner: 'design-system' } },
+      deprecated: { since: '2023-01-01' },
+      tags: ['governance'],
+    } satisfies NonNullable<ReturnType<typeof createPolicySnapshot>['metadata']>;
+    const resolution = { value: { computed: true } } as NonNullable<
+      ReturnType<typeof createPolicySnapshot>['resolution']
+    >;
+    const context = {
+      component: 'button',
+      layer: { absolute: '/workspace/tokens/button.json' },
+    } as const;
+
+    const snapshot = createPolicySnapshot({ metadata, resolution, context });
+
+    expect(snapshot.metadata).toEqual(metadata);
+    expect(snapshot.resolution).toEqual(resolution);
+    expect(snapshot.context).toBe(context);
+  });
 });


### PR DESCRIPTION
## Summary
- add extensive audit reporter tests covering multi-format output, error handling, and structured logging
- verify policy snapshot helpers preserve metadata and resolution overrides used by the reporter fixtures
- refactor shared timings fixture to streamline reporter test setup while preserving defaults

## Testing
- CI=1 pnpm lint
- pnpm lint:markdown
- CI=1 pnpm build
- CI=1 pnpm test --parallel=1
- CI=1 pnpm format:check
- CI=1 pnpm docs:build

------
https://chatgpt.com/codex/tasks/task_e_68fcb14698c48328baae726a0cd68ae5