### PR TITLE
test(cli): raise coverage across command modules

### DIFF
--- a/packages/cli/src/io/process-cli-io.spec.ts
+++ b/packages/cli/src/io/process-cli-io.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createProcessCliIo } from './process-cli-io.js';
+
+const createStubProcess = () => {
+  const stdout = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+  const stderr = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+  const stdin = {} as NodeJS.ReadStream;
+  const exit = vi.fn() as unknown as NodeJS.Process['exit'];
+
+  return {
+    stdin,
+    stdout,
+    stderr,
+    exit,
+    exitCode: undefined as number | undefined,
+  } as unknown as NodeJS.Process & { exitCode: number | undefined };
+};
+
+describe('createProcessCliIo', () => {
+  it('adapts the provided process IO streams', () => {
+    const stubProcess = createStubProcess();
+    const io = createProcessCliIo({ process: stubProcess });
+
+    io.writeOut('hello');
+    io.writeErr('oops');
+    io.exit(5);
+
+    expect(io.stdin).toBe(stubProcess.stdin);
+    expect(io.stdout).toBe(stubProcess.stdout);
+    expect(io.stderr).toBe(stubProcess.stderr);
+    expect(stubProcess.stdout.write).toHaveBeenCalledWith('hello');
+    expect(stubProcess.stderr.write).toHaveBeenCalledWith('oops');
+    expect(stubProcess.exit).toHaveBeenCalledWith(5);
+  });
+
+  it('reuses a non-zero exitCode when exiting with zero', () => {
+    const stubProcess = createStubProcess();
+    stubProcess.exitCode = 3;
+    const io = createProcessCliIo({ process: stubProcess });
+
+    io.exit(0);
+
+    expect(stubProcess.exit).toHaveBeenCalledWith(3);
+  });
+
+  it('prefers the explicit exit code when process exitCode is zero', () => {
+    const stubProcess = createStubProcess();
+    stubProcess.exitCode = 0;
+    const io = createProcessCliIo({ process: stubProcess });
+
+    io.exit(0);
+
+    expect(stubProcess.exit).toHaveBeenCalledWith(0);
+  });
+});

--- a/packages/cli/src/public-api.spec.ts
+++ b/packages/cli/src/public-api.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import * as cli from './index.js';
+import { createCliKernel } from './kernel/cli-kernel.js';
+import { createProcessCliIo } from './io/process-cli-io.js';
+import { auditCommandModule } from './tools/audit/audit-command-module.js';
+import { buildCommandModule } from './tools/build/build-command-module.js';
+import { extractCommandModule } from './tools/extract/extract-command-module.js';
+import { initCommandModule } from './tools/init/init-command-module.js';
+import { diffCommandModule } from './tools/diff/diff-command-module.js';
+import { createAuditCliKernel, runAuditCli } from './tools/audit/run-audit-cli.js';
+import { createBuildCliKernel, runBuildCli } from './tools/build/run-build-cli.js';
+import { createDiffCliKernel, runDiffCli } from './tools/diff/run-diff-cli.js';
+import { createExtractCliKernel, runExtractCli } from './tools/extract/run-extract-cli.js';
+
+describe('CLI public API surface', () => {
+  it('re-exports the primary CLI entry points', () => {
+    expect(cli.createCliKernel).toBe(createCliKernel);
+    expect(cli.createProcessCliIo).toBe(createProcessCliIo);
+    expect(cli.diffCommandModule).toBe(diffCommandModule);
+    expect(cli.buildCommandModule).toBe(buildCommandModule);
+    expect(cli.auditCommandModule).toBe(auditCommandModule);
+    expect(cli.initCommandModule).toBe(initCommandModule);
+    expect(cli.extractCommandModule).toBe(extractCommandModule);
+    expect(cli.createDiffCliKernel).toBe(createDiffCliKernel);
+    expect(cli.runDiffCli).toBe(runDiffCli);
+    expect(cli.createBuildCliKernel).toBe(createBuildCliKernel);
+    expect(cli.runBuildCli).toBe(runBuildCli);
+    expect(cli.createAuditCliKernel).toBe(createAuditCliKernel);
+    expect(cli.runAuditCli).toBe(runAuditCli);
+    expect(cli.createExtractCliKernel).toBe(createExtractCliKernel);
+    expect(cli.runExtractCli).toBe(runExtractCli);
+  });
+});

--- a/packages/cli/src/testing/index.spec.ts
+++ b/packages/cli/src/testing/index.spec.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-describe('@dtifx/cli/testing entry point', () => {
-  it('supports importing testing utilities', async () => {
-    // eslint-disable-next-line @nx/enforce-module-boundaries
-    await expect(import('@dtifx/cli/testing')).resolves.toHaveProperty('createMemoryCliIo');
+import * as testing from './index.js';
+import { createMemoryCliIo } from './memory-cli-io.js';
+
+describe('testing utilities public API', () => {
+  it('re-exports the in-memory CLI IO helpers', () => {
+    expect(testing.createMemoryCliIo).toBe(createMemoryCliIo);
   });
 });

--- a/packages/cli/src/testing/memory-cli-io.spec.ts
+++ b/packages/cli/src/testing/memory-cli-io.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMemoryCliIo } from './memory-cli-io.js';
+
+describe('createMemoryCliIo', () => {
+  it('captures output buffers and recorded exit codes', () => {
+    const io = createMemoryCliIo();
+
+    io.writeOut('hello');
+    io.writeErr('error');
+
+    expect(io.stdoutBuffer).toBe('hello');
+    expect(io.stderrBuffer).toBe('error');
+    expect(io.exitCodes).toEqual([]);
+
+    expect(() => io.exit(2)).toThrow(/process exit called with code 2/);
+    expect(io.exitCodes).toEqual([2]);
+  });
+});

--- a/packages/cli/src/tools/audit/audit-command-module.spec.ts
+++ b/packages/cli/src/tools/audit/audit-command-module.spec.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import process from 'node:process';
 
 import { createCliKernel } from '../../kernel/cli-kernel.js';
@@ -116,5 +116,25 @@ describe('auditCommandModule', () => {
     expect(executeAuditCommand).not.toHaveBeenCalled();
     expect(io.stderrBuffer).toContain('Please install @dtifx/audit');
     expect(process.exitCode).toBeUndefined();
+  });
+
+  it('shows help output when the audit command is invoked directly', async () => {
+    const io = createMemoryCliIo();
+    const kernel = createCliKernel({ ...kernelOptions, io });
+
+    kernel.register(auditCommandModule);
+
+    const helpSpy = vi.spyOn(Command.prototype, 'help').mockImplementation(function () {
+      io.writeOut('audit help\n');
+      return this as never;
+    });
+
+    const exitCode = await kernel.run(['node', 'dtifx', 'audit']);
+
+    expect(exitCode).toBe(0);
+    expect(helpSpy).toHaveBeenCalled();
+    expect(io.stdoutBuffer).toContain('audit help');
+
+    helpSpy.mockRestore();
   });
 });

--- a/packages/cli/src/tools/audit/audit-module-loader.spec.ts
+++ b/packages/cli/src/tools/audit/audit-module-loader.spec.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createMemoryCliIo } from '../../testing/memory-cli-io.js';
+
+const loadModule = async () => import('./audit-module-loader.js');
+
+describe('loadAuditModule', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    const { setAuditModuleImporterForTesting } = await loadModule();
+    setAuditModuleImporterForTesting();
+    vi.clearAllMocks();
+  });
+
+  it('returns the audit module when available', async () => {
+    const fakeAudit = { runAudit: vi.fn() } as const;
+    const { loadAuditModule, setAuditModuleImporterForTesting } = await loadModule();
+    setAuditModuleImporterForTesting(async () => fakeAudit);
+    const io = createMemoryCliIo();
+
+    const module = await loadAuditModule({ io });
+
+    expect(module).toBe(fakeAudit);
+    expect(io.stderrBuffer).toBe('');
+  });
+
+  it('logs a friendly message when the module is missing', async () => {
+    const missingModuleError = Object.assign(new Error('Module not found'), {
+      code: 'ERR_MODULE_NOT_FOUND',
+    });
+    const { loadAuditModule, setAuditModuleImporterForTesting } = await loadModule();
+    setAuditModuleImporterForTesting(async () => {
+      throw missingModuleError;
+    });
+    const io = createMemoryCliIo();
+
+    const module = await loadAuditModule({ io });
+
+    expect(module).toBeUndefined();
+    expect(io.stderrBuffer).toContain('Please install @dtifx/audit');
+  });
+});

--- a/packages/cli/src/tools/audit/audit-module-loader.ts
+++ b/packages/cli/src/tools/audit/audit-module-loader.ts
@@ -10,9 +10,21 @@ export type AuditModule = typeof Audit;
 
 export type LoadAuditModule = (options: LoadAuditModuleOptions) => Promise<AuditModule | undefined>;
 
+type AuditModuleImporter = () => Promise<AuditModule>;
+
+const defaultImportAuditModule: AuditModuleImporter = () => import('@dtifx/audit');
+
+let importAuditModule: AuditModuleImporter = defaultImportAuditModule;
+
+export const setAuditModuleImporterForTesting = (
+  importer?: AuditModuleImporter | undefined,
+): void => {
+  importAuditModule = importer ?? defaultImportAuditModule;
+};
+
 export const loadAuditModule: LoadAuditModule = async ({ io }) => {
   try {
-    return await import('@dtifx/audit');
+    return await importAuditModule();
   } catch (error) {
     if (isModuleNotFoundError(error)) {
       io.writeErr('The "@dtifx/audit" package is required. Please install @dtifx/audit.\n');

--- a/packages/cli/src/tools/build/build-module.spec.ts
+++ b/packages/cli/src/tools/build/build-module.spec.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CliIo } from '../../io/cli-io.js';
+
+const createIo = (): CliIo => ({
+  stdin: {} as NodeJS.ReadStream,
+  stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+  stderr: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+  writeOut: vi.fn(),
+  writeErr: vi.fn(),
+  exit: vi.fn() as unknown as CliIo['exit'],
+});
+
+describe('build module loaders', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('loads the @dtifx/build module once and reuses the cached promise', async () => {
+    const { loadBuildModule, setBuildModuleImportersForTesting } = await import(
+      './build-module.js'
+    );
+    const buildModule = { symbol: Symbol('build') } as Awaited<ReturnType<typeof loadBuildModule>>;
+    setBuildModuleImportersForTesting({ build: async () => buildModule });
+    const io = createIo();
+
+    const first = await loadBuildModule(io);
+    const second = await loadBuildModule(io);
+
+    expect(first?.symbol).toBe(buildModule.symbol);
+    expect(second).toBe(first);
+  });
+
+  it('informs users when @dtifx/build cannot be resolved', async () => {
+    const { loadBuildModule, setBuildModuleImportersForTesting } = await import(
+      './build-module.js'
+    );
+    setBuildModuleImportersForTesting({
+      build: async () => {
+        const error = new Error('module not found') as NodeJS.ErrnoException;
+        error.code = 'ERR_MODULE_NOT_FOUND';
+        throw error;
+      },
+    });
+    const io = createIo();
+
+    let thrown: unknown;
+    let result: Awaited<ReturnType<typeof loadBuildModule>> | undefined;
+    try {
+      result = await loadBuildModule(io);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeUndefined();
+    expect(result).toBeUndefined();
+    expect(io.writeErr).toHaveBeenCalledWith(
+      'The "@dtifx/build" package is required. Please install @dtifx/build.\n',
+    );
+  });
+
+  it('rethrows unexpected load errors for @dtifx/build', async () => {
+    const { loadBuildModule, setBuildModuleImportersForTesting } = await import(
+      './build-module.js'
+    );
+    setBuildModuleImportersForTesting({
+      build: async () => {
+        throw new Error('unexpected failure');
+      },
+    });
+    const io = createIo();
+
+    await expect(loadBuildModule(io)).rejects.toThrow('unexpected failure');
+  });
+
+  it('loads the @dtifx/build reporter module and caches results', async () => {
+    const { loadBuildReporterModule, setBuildModuleImportersForTesting } = await import(
+      './build-module.js'
+    );
+    const reporterModule = { reporters: true } as Awaited<
+      ReturnType<typeof loadBuildReporterModule>
+    >;
+    setBuildModuleImportersForTesting({ reporters: async () => reporterModule });
+    const io = createIo();
+
+    const first = await loadBuildReporterModule(io);
+    const second = await loadBuildReporterModule(io);
+
+    expect(first?.reporters).toBe(true);
+    expect(second).toBe(first);
+  });
+
+  it('reports missing reporter modules gracefully', async () => {
+    const { loadBuildReporterModule, setBuildModuleImportersForTesting } = await import(
+      './build-module.js'
+    );
+    setBuildModuleImportersForTesting({
+      reporters: async () => {
+        const error = new Error('module not found') as NodeJS.ErrnoException;
+        error.code = 'ERR_MODULE_NOT_FOUND';
+        throw error;
+      },
+    });
+    const io = createIo();
+
+    let thrown: unknown;
+    let result: Awaited<ReturnType<typeof loadBuildReporterModule>> | undefined;
+    try {
+      result = await loadBuildReporterModule(io);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeUndefined();
+    expect(result).toBeUndefined();
+    expect(io.writeErr).toHaveBeenCalledWith(
+      'The "@dtifx/build" package is required. Please install @dtifx/build.\n',
+    );
+  });
+
+  it('loads build modules using the default importers', async () => {
+    vi.doMock('@dtifx/build', () => ({ createBuildPipeline: vi.fn() }), { virtual: true });
+    vi.doMock('@dtifx/build/cli/reporters', () => ({ reporters: ['json'] }), { virtual: true });
+
+    const { loadBuildModule, loadBuildReporterModule, setBuildModuleImportersForTesting } =
+      await import('./build-module.js');
+    const io = createIo();
+
+    const module = await loadBuildModule(io);
+    expect(module).toBeDefined();
+
+    const reporters = await loadBuildReporterModule(io);
+    expect(reporters).toBeDefined();
+
+    setBuildModuleImportersForTesting();
+
+    const moduleAfterReset = await loadBuildModule(io);
+    expect(moduleAfterReset).toBeDefined();
+
+    const reportersAfterReset = await loadBuildReporterModule(io);
+    expect(reportersAfterReset).toBeDefined();
+  });
+});

--- a/packages/cli/src/tools/build/environment.spec.ts
+++ b/packages/cli/src/tools/build/environment.spec.ts
@@ -1,0 +1,223 @@
+import { PassThrough } from 'node:stream';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CliIo } from '../../io/cli-io.js';
+import { createMemoryCliIo } from '../../testing/memory-cli-io.js';
+import { prepareBuildEnvironment } from './environment.js';
+import { setBuildModuleImportersForTesting } from './build-module.js';
+
+type BuildDependencies = NonNullable<
+  Parameters<typeof setBuildModuleImportersForTesting>[0]
+>['build'] extends infer T
+  ? NonNullable<T>
+  : never;
+type ReporterDependencies = NonNullable<
+  Parameters<typeof setBuildModuleImportersForTesting>[0]
+>['reporters'] extends infer T
+  ? NonNullable<T>
+  : never;
+
+const createInteractiveIo = (): CliIo & { stderrBuffer: string[] } => {
+  const stdoutBuffer: string[] = [];
+  const stderrBuffer: string[] = [];
+  const stdout = Object.assign(new PassThrough(), {
+    write(chunk: string | Uint8Array) {
+      stdoutBuffer.push(chunk.toString());
+      return true;
+    },
+  });
+  const stderr = Object.assign(new PassThrough(), {
+    isTTY: true as const,
+    write(chunk: string | Uint8Array) {
+      stderrBuffer.push(chunk.toString());
+      return true;
+    },
+  });
+
+  return {
+    stdin: new PassThrough(),
+    stdout,
+    stderr,
+    stderrBuffer,
+    writeOut(chunk: string) {
+      stdoutBuffer.push(chunk);
+    },
+    writeErr(chunk: string) {
+      stderrBuffer.push(chunk);
+    },
+    exit: vi.fn(),
+  } satisfies CliIo & { stderrBuffer: string[] };
+};
+
+const createBuildMocks = () => {
+  const configPath = '/workspace/dtifx.config.js';
+  const loadedConfig = {
+    config: { formatters: [] },
+    directory: '/workspace',
+    path: configPath,
+  } as const;
+  const unsubscribe = vi.fn();
+  const subscribe = vi.fn(() => ({ unsubscribe }));
+  const tracerSpan = { end: vi.fn() };
+  const telemetryRuntime = {
+    tracer: {
+      startSpan: vi.fn(() => tracerSpan),
+    },
+    exportSpans: vi.fn(async () => {}),
+  };
+
+  const build: BuildDependencies = {
+    resolveConfigPath: vi.fn(async () => configPath),
+    loadConfig: vi.fn(async () => loadedConfig),
+    loadFormatterDefinitionRegistry: vi.fn(async () => ({ formatters: true })),
+    loadTransformDefinitionRegistry: vi.fn(async () => ({ transforms: true })),
+    loadDependencyStrategyRegistry: vi.fn(async () => ({ dependencies: true })),
+    loadPolicyRuleRegistry: vi.fn(async () => ({ policies: true })),
+    createTelemetryRuntime: vi.fn(() => telemetryRuntime),
+    createBuildStageLoggingSubscriber: vi.fn(() => vi.fn()),
+    createDefaultBuildEnvironment: vi.fn(() => ({
+      documentCache: { kind: 'document-cache' },
+      tokenCache: { kind: 'token-cache' },
+      policyConfiguration: { kind: 'policy' },
+      services: {
+        eventBus: { subscribe },
+      },
+    })),
+    JsonLineLogger: vi.fn(function (this: unknown, stream: NodeJS.WritableStream) {
+      Object.assign(this, { stream, log: vi.fn() });
+    }),
+    noopLogger: { log: vi.fn() },
+  } as unknown as BuildDependencies;
+
+  const reporters: ReporterDependencies = {
+    formatDurationMs: vi.fn(() => '5ms'),
+  } as ReporterDependencies;
+
+  return { build, reporters, telemetryRuntime, subscribe, unsubscribe, loadedConfig };
+};
+
+describe('prepareBuildEnvironment', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    setBuildModuleImportersForTesting();
+  });
+
+  afterEach(() => {
+    setBuildModuleImportersForTesting();
+  });
+
+  it('returns undefined when the build module cannot be loaded', async () => {
+    const io = createMemoryCliIo();
+    const reporters: ReporterDependencies = {
+      formatDurationMs: vi.fn(() => '0ms'),
+    } as ReporterDependencies;
+    setBuildModuleImportersForTesting({
+      // eslint-disable-next-line unicorn/no-useless-undefined -- simulating unresolved module
+      build: async () => undefined,
+      reporters: async () => reporters,
+    });
+    const result = await prepareBuildEnvironment({ jsonLogs: false, timings: false }, io);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when the reporters module is unavailable', async () => {
+    const io = createMemoryCliIo();
+    const { build, reporters } = createBuildMocks();
+    setBuildModuleImportersForTesting({
+      build: async () => build,
+      // eslint-disable-next-line unicorn/no-useless-undefined -- simulating unresolved reporters
+      reporters: async () => undefined,
+    });
+    const result = await prepareBuildEnvironment({ jsonLogs: false, timings: false }, io);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('configures the build environment with interactive logging', async () => {
+    const io = createInteractiveIo();
+    const { build, reporters, telemetryRuntime, subscribe, unsubscribe, loadedConfig } =
+      createBuildMocks();
+    const documentCache = { source: 'document-cache' } as unknown;
+    const tokenCache = { source: 'token-cache' } as unknown;
+
+    setBuildModuleImportersForTesting({
+      build: async () => build,
+      reporters: async () => reporters,
+    });
+
+    const result = await prepareBuildEnvironment(
+      {
+        config: 'dtifx.config.ts',
+        outDir: 'dist/out',
+        jsonLogs: false,
+        timings: true,
+        telemetry: 'stdout',
+      },
+      io,
+      documentCache,
+      tokenCache,
+    );
+
+    expect(result).toBeDefined();
+    expect(build.resolveConfigPath).toHaveBeenCalledWith({ configPath: 'dtifx.config.ts' });
+    expect(build.loadFormatterDefinitionRegistry).toHaveBeenCalledWith({
+      config: loadedConfig.config,
+      configDirectory: loadedConfig.directory,
+      configPath: loadedConfig.path,
+    });
+    expect(build.createTelemetryRuntime).toHaveBeenCalledWith(
+      'stdout',
+      expect.objectContaining({ logger: expect.any(Object) }),
+    );
+    expect(build.createDefaultBuildEnvironment).toHaveBeenCalledWith(
+      {
+        config: loadedConfig.config,
+        configDirectory: loadedConfig.directory,
+        configPath: loadedConfig.path,
+      },
+      expect.objectContaining({
+        defaultOutDir: 'dist/out',
+        documentCache,
+        tokenCache,
+        runtime: { flatten: true, includeGraphs: true },
+      }),
+    );
+
+    const environment = result!;
+    expect(environment.documentCache).toEqual({ kind: 'document-cache' });
+    expect(environment.tokenCache).toEqual({ kind: 'token-cache' });
+
+    environment.logger.log({
+      level: 'info',
+      event: 'build.complete',
+      elapsedMs: 42,
+      data: { ok: true },
+    });
+    expect(reporters.formatDurationMs).toHaveBeenCalledWith(42);
+    expect(io.stderrBuffer.join('')).toContain('[info] build.complete');
+    expect(io.stderrBuffer.join('')).toContain('5ms');
+
+    environment.dispose();
+    environment.dispose();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    await environment.telemetry.exportSpans();
+    expect(telemetryRuntime.exportSpans).toHaveBeenCalled();
+    expect(subscribe).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('uses the JSON logger when structured logging is requested', async () => {
+    const io = createMemoryCliIo();
+    const { build, reporters } = createBuildMocks();
+
+    setBuildModuleImportersForTesting({
+      build: async () => build,
+      reporters: async () => reporters,
+    });
+
+    await prepareBuildEnvironment({ jsonLogs: true, timings: false }, io);
+
+    expect(build.JsonLineLogger).toHaveBeenCalledWith(io.stdout);
+  });
+});

--- a/packages/cli/src/tools/diff/diagnostics.spec.ts
+++ b/packages/cli/src/tools/diff/diagnostics.spec.ts
@@ -1,94 +1,127 @@
 import { describe, expect, it } from 'vitest';
 
 import { createMemoryCliIo } from '../../testing/memory-cli-io.js';
-import type { CompareCommandOptions } from './compare-options.js';
-import { createReportingDiagnosticsPort } from './diagnostics.js';
+import {
+  createDiagnosticSink,
+  createReportingDiagnosticsPort,
+  selectDiagnosticDecorator,
+} from './diagnostics.js';
 
-type OptionOverrides = Partial<CompareCommandOptions>;
+type DiagnosticInput = Parameters<ReturnType<typeof createDiagnosticSink>>[0];
+type ReportingEvent = Parameters<ReturnType<typeof createReportingDiagnosticsPort>['emit']>[0];
 
-const createOptions = (overrides: OptionOverrides = {}): CompareCommandOptions => ({
-  format: 'cli',
-  color: false,
-  unicode: undefined,
-  templatePartials: [],
-  templateAllowUnescapedOutput: false,
-  filterTypes: [],
-  filterPaths: [],
-  filterGroups: [],
-  filterImpacts: [],
-  filterKinds: [],
-  mode: 'condensed',
-  failOnBreaking: false,
-  failOnChanges: false,
-  verbose: false,
-  why: false,
-  diffContext: 3,
-  topRisks: 5,
-  links: false,
-  quiet: false,
-  templatePath: undefined,
-  outputPath: undefined,
-  renameStrategy: undefined,
-  impactStrategy: undefined,
-  summaryStrategy: undefined,
-  ...overrides,
-});
+describe('diff diagnostics helpers', () => {
+  const baseOptions = {
+    format: 'cli',
+    color: false,
+    templatePartials: [],
+    templateAllowUnescapedOutput: false,
+    filterTypes: [],
+    filterPaths: [],
+    filterGroups: [],
+    filterImpacts: [],
+    filterKinds: [],
+    mode: 'full',
+    failOnBreaking: false,
+    failOnChanges: false,
+    verbose: false,
+    why: false,
+    diffContext: 0,
+    topRisks: 0,
+    links: false,
+    quiet: false,
+  } as const;
 
-describe('createReportingDiagnosticsPort', () => {
-  it('writes formatted diagnostics to stderr', () => {
+  it('suppresses parser diagnostics when quiet mode is enabled', () => {
     const io = createMemoryCliIo();
-    const port = createReportingDiagnosticsPort(createOptions(), io);
+    const sink = createDiagnosticSink({ ...baseOptions, quiet: true }, io);
 
-    port.emit({ level: 'warn', message: 'template missing partials', scope: 'renderer' });
-
-    expect(io.stderrBuffer).toContain('[WARN] renderer: template missing partials');
-  });
-
-  it('includes diagnostic codes when provided', () => {
-    const io = createMemoryCliIo();
-    const port = createReportingDiagnosticsPort(createOptions(), io);
-
-    port.emit({
-      level: 'info',
-      message: 'normalized width to 80 columns',
-      code: 'CLI_WIDTH_NORMALIZED',
-    });
-
-    expect(io.stderrBuffer).toContain('[INFO] CLI_WIDTH_NORMALIZED normalized width to 80 columns');
-  });
-
-  it('includes diagnostic categories when provided', () => {
-    const io = createMemoryCliIo();
-    const port = createReportingDiagnosticsPort(createOptions(), io);
-
-    port.emit({
-      level: 'info',
-      message: 'render started',
-      code: 'REPORT_RENDER_START',
-      scope: 'reporting.cli' as never,
-      category: 'reportingRegistry' as never,
-    });
-
-    expect(io.stderrBuffer).toContain(
-      '[INFO] [reportingRegistry] reporting.cli: REPORT_RENDER_START render started',
-    );
-  });
-
-  it('suppresses diagnostics when quiet', () => {
-    const io = createMemoryCliIo();
-    const port = createReportingDiagnosticsPort(createOptions({ quiet: true }), io);
-
-    port.emit({ level: 'info', message: 'this should not appear' });
+    sink({
+      severity: 'warn',
+      code: 'warn-code',
+      message: 'This should not be logged',
+    } as unknown as DiagnosticInput);
 
     expect(io.stderrBuffer).toBe('');
   });
 
-  it('applies ANSI colors when enabled', () => {
+  it('deduplicates and decorates parser diagnostics', () => {
     const io = createMemoryCliIo();
-    const port = createReportingDiagnosticsPort(createOptions({ color: true }), io);
+    const sink = createDiagnosticSink(baseOptions, io);
 
-    port.emit({ level: 'error', message: 'render failed' });
+    const diagnostic = {
+      severity: 'warn',
+      code: 'parser-code',
+      message: 'Token missing optional field',
+      pointer: '/tokens/0/value',
+      span: { start: { line: 5, column: 10 } },
+    } as unknown as DiagnosticInput;
 
-    expect(io.stderrBuffer).toMatch(/\u001B\[31m\[ERROR\] render failed\u001B\[0m/);
+    sink(diagnostic);
+    sink(diagnostic);
+    sink({ ...diagnostic, severity: 'error' });
+
+    expect(io.stderrBuffer).toContain('WARN parser-code - Token missing optional field');
+    expect(io.stderrBuffer).toContain('(/tokens/0/value)');
+    expect(io.stderrBuffer).toContain('(5:10)');
+    expect(io.stderrBuffer.match(/Token missing optional field/g)?.length).toBe(1);
+  });
+
+  it('applies colorization when requested for parser diagnostics', () => {
+    const io = createMemoryCliIo();
+    const sink = createDiagnosticSink({ ...baseOptions, color: true }, io);
+
+    sink({
+      severity: 'warn',
+      code: 'parser-code',
+      message: 'Colored warning',
+    } as unknown as DiagnosticInput);
+
+    expect(io.stderrBuffer).toContain('\u001B[33m');
+    expect(io.stderrBuffer).toContain('Colored warning');
+  });
+
+  it('suppresses reporting diagnostics in quiet mode', () => {
+    const io = createMemoryCliIo();
+    const port = createReportingDiagnosticsPort({ ...baseOptions, quiet: true }, io);
+
+    port.emit({ level: 'warn', message: 'Hidden warning' } as unknown as ReportingEvent);
+
+    expect(io.stderrBuffer).toBe('');
+  });
+
+  it('formats reporting diagnostics without color', () => {
+    const io = createMemoryCliIo();
+    const port = createReportingDiagnosticsPort(baseOptions, io);
+
+    port.emit({
+      level: 'info',
+      message: 'Loaded formatter module',
+      scope: 'formatter-loader',
+      category: 'lifecycle',
+      code: 'loader-info',
+    } as unknown as ReportingEvent);
+
+    expect(io.stderrBuffer).toContain(
+      '[INFO] [lifecycle] formatter-loader: loader-info Loaded formatter module',
+    );
+  });
+
+  it('applies ANSI colors to reporting diagnostics when enabled', () => {
+    const io = createMemoryCliIo();
+    const port = createReportingDiagnosticsPort({ ...baseOptions, color: true }, io);
+
+    port.emit({ level: 'warn', message: 'Colored reporting message' } as unknown as ReportingEvent);
+
+    expect(io.stderrBuffer).toContain('\u001B[33m');
+    expect(io.stderrBuffer).toContain('Colored reporting message');
+  });
+
+  it('selects diagnostic decorators based on color preference', () => {
+    const decorated = selectDiagnosticDecorator(true)('message', 'warn');
+    const plain = selectDiagnosticDecorator(false)('message', 'warn');
+
+    expect(decorated).toContain('\u001B[');
+    expect(plain).toBe('message');
   });
 });

--- a/packages/cli/src/tools/diff/diff-package-version.spec.ts
+++ b/packages/cli/src/tools/diff/diff-package-version.spec.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCreateRequire = vi.hoisted(() => vi.fn<(specifier: string | URL) => StubRequire>());
+
+vi.mock('node:module', () => ({
+  createRequire: mockCreateRequire,
+}));
+
+import { loadDiffPackageVersion } from './diff-package-version.js';
+
+type StubRequire = NodeRequire & {
+  setManifest(manifestPath: string, manifest: unknown): void;
+};
+
+const createStubRequire = (): StubRequire => {
+  const manifests = new Map<string, unknown>();
+  const requireImplementation = ((request: string) => {
+    if (!manifests.has(request)) {
+      throw Object.assign(new Error(`Cannot find module ${request}`), { code: 'MODULE_NOT_FOUND' });
+    }
+    return manifests.get(request);
+  }) as NodeRequire;
+
+  const resolve = vi.fn((specifier: string) => {
+    if (specifier === '@dtifx/diff') {
+      return '/virtual/node_modules/@dtifx/diff/dist/index.js';
+    }
+    throw new Error(`Cannot resolve ${specifier}`);
+  });
+
+  const stubRequire = Object.assign(requireImplementation, {
+    cache: Object.create(null),
+    extensions: Object.create(null),
+    main: undefined,
+    resolve,
+    setManifest: (manifestPath: string, manifest: unknown) => {
+      manifests.set(manifestPath, manifest);
+    },
+  });
+
+  return stubRequire;
+};
+
+describe('loadDiffPackageVersion', () => {
+  beforeEach(() => {
+    mockCreateRequire.mockReset();
+  });
+
+  it('returns the installed @dtifx/diff version when available', () => {
+    const stubRequire = createStubRequire();
+    stubRequire.setManifest('/virtual/node_modules/@dtifx/diff/package.json', {
+      name: '@dtifx/diff',
+      version: '1.2.3',
+    });
+
+    mockCreateRequire.mockReturnValue(stubRequire);
+
+    expect(loadDiffPackageVersion()).toBe('1.2.3');
+    expect(stubRequire.resolve).toHaveBeenCalledWith('@dtifx/diff');
+  });
+
+  it('walks up directories until it finds the package manifest', () => {
+    const stubRequire = createStubRequire();
+    mockCreateRequire.mockReturnValue(stubRequire);
+    vi.mocked(stubRequire.resolve).mockReturnValue(
+      '/virtual/node_modules/@dtifx/diff/lib/index.js',
+    );
+
+    stubRequire.setManifest('/virtual/node_modules/@dtifx/diff/package.json', {
+      name: '@dtifx/diff',
+      version: '9.9.9',
+    });
+
+    expect(loadDiffPackageVersion()).toBe('9.9.9');
+  });
+
+  it('returns undefined when the package cannot be resolved', () => {
+    const stubRequire = createStubRequire();
+    mockCreateRequire.mockReturnValue(stubRequire);
+    vi.mocked(stubRequire.resolve).mockImplementation(() => {
+      throw new Error('missing package');
+    });
+
+    expect(loadDiffPackageVersion()).toBeUndefined();
+  });
+});

--- a/packages/cli/src/tools/diff/failures.spec.ts
+++ b/packages/cli/src/tools/diff/failures.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatFailureMessage } from './failures.js';
+
+describe('formatFailureMessage', () => {
+  it('formats breaking change failures with pluralization', () => {
+    const message = formatFailureMessage({
+      reason: 'breaking-changes',
+      matchedCount: 2,
+    } as unknown as Parameters<typeof formatFailureMessage>[0]);
+
+    expect(message).toBe(
+      'DTIFx diff: failing because 2 breaking changes detected (--fail-on-breaking).',
+    );
+  });
+
+  it('formats token change failures with singular labels', () => {
+    const message = formatFailureMessage({
+      reason: 'token-changes',
+      matchedCount: 1,
+    } as unknown as Parameters<typeof formatFailureMessage>[0]);
+
+    expect(message).toBe(
+      'DTIFx diff: failing because 1 token change detected (--fail-on-changes).',
+    );
+  });
+
+  it('falls back to a generic failure message for other reasons', () => {
+    const message = formatFailureMessage({
+      reason: 'custom-policy',
+    } as unknown as Parameters<typeof formatFailureMessage>[0]);
+
+    expect(message).toBe('DTIFx diff: failing because a diff failure policy was triggered.');
+  });
+});

--- a/packages/cli/src/tools/diff/strategies.spec.ts
+++ b/packages/cli/src/tools/diff/strategies.spec.ts
@@ -35,7 +35,11 @@ describe('loadDiffStrategies', () => {
       remainingRemoved: [],
       remainingAdded: [],
     });
-    expect(strategies!.impactStrategy!.classifyAddition({} as never)).toBe('breaking');
+    const impactStrategy = strategies!.impactStrategy!;
+    expect(impactStrategy.classifyAddition({} as never)).toBe('breaking');
+    expect(impactStrategy.classifyRemoval({} as never)).toBe('non-breaking');
+    expect(impactStrategy.classifyRename({} as never)).toBe('breaking');
+    expect(impactStrategy.classifyModification({} as never)).toBe('non-breaking');
     const summary = strategies!.summaryStrategy!.createSummary({
       previous: new Map(),
       next: new Map(),
@@ -61,7 +65,16 @@ describe('loadDiffStrategies', () => {
       strategies!.impactStrategy!,
     );
     expect(renameResult?.remainingRemoved.length).toBe(0);
-    expect(strategies?.impactStrategy?.classifyRemoval({} as never)).toBe('breaking');
+    const impactStrategy = strategies?.impactStrategy!;
+    expect(impactStrategy.classifyAddition({} as never)).toBe('non-breaking');
+    expect(impactStrategy.classifyRemoval({} as never)).toBe('breaking');
+    expect(impactStrategy.classifyRename({} as never)).toBe('non-breaking');
+    expect(impactStrategy.classifyModification({ metadataChanged: true } as never)).toBe(
+      'non-breaking',
+    );
+    expect(impactStrategy.classifyModification({ metadataChanged: false } as never)).toBe(
+      'breaking',
+    );
 
     const summary = await strategies?.summaryStrategy?.createSummary({
       previous: new Map(),

--- a/packages/cli/src/tools/extract/extract-command-module.spec.ts
+++ b/packages/cli/src/tools/extract/extract-command-module.spec.ts
@@ -2,13 +2,29 @@ import path from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { extractFigmaTokens as extractFigmaTokensType } from '@dtifx/extractors';
+import type {
+  extractFigmaTokens as extractFigmaTokensType,
+  extractPenpotTokens as extractPenpotTokensType,
+  extractSketchTokens as extractSketchTokensType,
+} from '@dtifx/extractors';
 
 type ExtractFigmaTokens = typeof extractFigmaTokensType;
+type ExtractPenpotTokens = typeof extractPenpotTokensType;
+type ExtractSketchTokens = typeof extractSketchTokensType;
+
 const extractFigmaTokensMock = vi.fn<ExtractFigmaTokens>();
+const extractPenpotTokensMock = vi.fn<ExtractPenpotTokens>();
+const extractSketchTokensMock = vi.fn<ExtractSketchTokens>();
+
+vi.mock('@dtifx/core', () => ({
+  formatUnknownError: (error: unknown) =>
+    error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+}));
 
 vi.mock('@dtifx/extractors', () => ({
   extractFigmaTokens: extractFigmaTokensMock,
+  extractPenpotTokens: extractPenpotTokensMock,
+  extractSketchTokens: extractSketchTokensMock,
 }));
 
 interface FigmaNodesFixture {
@@ -39,9 +55,12 @@ describe('extractCommandModule', () => {
 
   beforeEach(async () => {
     extractFigmaTokensMock.mockReset();
+    extractPenpotTokensMock.mockReset();
+    extractSketchTokensMock.mockReset();
     mkdir.mockReset();
     writeFile.mockReset();
     delete process.env.FIGMA_ACCESS_TOKEN;
+    delete process.env.PENPOT_ACCESS_TOKEN;
   });
 
   it('writes extracted Figma tokens to the requested file', async () => {
@@ -129,5 +148,191 @@ describe('extractCommandModule', () => {
     const warningArguments = extractFigmaTokensMock.mock.calls[0]?.[0];
     expect(warningArguments?.nodeIds).toBeUndefined();
     expect(io.stderrBuffer).toContain('Warning: Sample warning');
+  });
+
+  it('supports optional Figma arguments for node filtering and API overrides', async () => {
+    const io = createMemoryCliIo();
+    const kernel = createCliKernel({ ...kernelOptions, io });
+
+    kernel.register(extractCommandModule);
+
+    extractFigmaTokensMock.mockResolvedValue({
+      document: { ok: true },
+      warnings: [],
+    });
+
+    const exitCode = await kernel.run([
+      'node',
+      'dtifx',
+      'extract',
+      'figma',
+      '--file',
+      'with-nodes',
+      '--token',
+      'token',
+      '--node',
+      'first',
+      '--node',
+      'second',
+      '--api-base',
+      'https://api.figma.test',
+    ]);
+
+    expect(exitCode).toBe(0);
+    const options = extractFigmaTokensMock.mock.calls[0]?.[0];
+    expect(options).toMatchObject({
+      fileKey: 'with-nodes',
+      personalAccessToken: 'token',
+      apiBaseUrl: 'https://api.figma.test',
+      nodeIds: ['first', 'second'],
+    });
+    const defaultOutput = path.resolve(path.join('tokens', 'with-nodes.figma.json'));
+    expect(writeFile).toHaveBeenCalledWith(defaultOutput, expect.any(String), 'utf8');
+  });
+
+  it('reports unexpected Figma extraction failures', async () => {
+    const io = createMemoryCliIo();
+    const kernel = createCliKernel({ ...kernelOptions, io });
+
+    kernel.register(extractCommandModule);
+
+    extractFigmaTokensMock.mockRejectedValue(new Error('network outage'));
+
+    const exitCode = await kernel.run([
+      'node',
+      'dtifx',
+      'extract',
+      'figma',
+      '--file',
+      'abc123',
+      '--token',
+      'token',
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(io.stderrBuffer).toContain('Failed to extract Figma tokens: Error: network outage');
+  });
+
+  it('writes Penpot tokens using environment credentials when available', async () => {
+    const io = createMemoryCliIo();
+    const kernel = createCliKernel({ ...kernelOptions, io });
+
+    kernel.register(extractCommandModule);
+
+    process.env.PENPOT_ACCESS_TOKEN = 'penpot-token';
+    extractPenpotTokensMock.mockResolvedValue({
+      document: { ok: true },
+      warnings: [{ code: 'slow-api', message: 'Penpot warning' }],
+    });
+
+    const exitCode = await kernel.run([
+      'node',
+      'dtifx',
+      'extract',
+      'penpot',
+      '--file',
+      'penpot-file',
+      '--api-base',
+      'https://penpot.test',
+    ]);
+
+    expect(exitCode).toBe(0);
+    const options = extractPenpotTokensMock.mock.calls[0]?.[0];
+    expect(options).toMatchObject({
+      fileId: 'penpot-file',
+      accessToken: 'penpot-token',
+      apiBaseUrl: 'https://penpot.test',
+    });
+    const defaultOutput = path.resolve(path.join('tokens', 'penpot-file.penpot.json'));
+    expect(writeFile).toHaveBeenCalledWith(defaultOutput, expect.any(String), 'utf8');
+    expect(io.stderrBuffer).toContain('Warning: Penpot warning');
+  });
+
+  it('fails when Penpot credentials are missing', async () => {
+    const io = createMemoryCliIo();
+    const kernel = createCliKernel({ ...kernelOptions, io });
+
+    kernel.register(extractCommandModule);
+
+    const exitCode = await kernel.run([
+      'node',
+      'dtifx',
+      'extract',
+      'penpot',
+      '--file',
+      'missing-token',
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(io.stderrBuffer).toContain('Penpot access token is required');
+    expect(extractPenpotTokensMock).not.toHaveBeenCalled();
+  });
+
+  it('reports unexpected Penpot extraction failures', async () => {
+    const io = createMemoryCliIo();
+    const kernel = createCliKernel({ ...kernelOptions, io });
+
+    kernel.register(extractCommandModule);
+
+    process.env.PENPOT_ACCESS_TOKEN = 'penpot-token';
+    extractPenpotTokensMock.mockRejectedValue(new Error('penpot offline'));
+
+    const exitCode = await kernel.run([
+      'node',
+      'dtifx',
+      'extract',
+      'penpot',
+      '--file',
+      'penpot-file',
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(io.stderrBuffer).toContain('Failed to extract Penpot tokens: Error: penpot offline');
+  });
+
+  it('writes Sketch tokens to the derived default output path', async () => {
+    const io = createMemoryCliIo();
+    const kernel = createCliKernel({ ...kernelOptions, io });
+
+    kernel.register(extractCommandModule);
+
+    extractSketchTokensMock.mockResolvedValue({ document: { ok: true }, warnings: [] });
+
+    const sketchSource = path.join('fixtures', 'brand.sketch');
+    const exitCode = await kernel.run([
+      'node',
+      'dtifx',
+      'extract',
+      'sketch',
+      '--file',
+      sketchSource,
+    ]);
+
+    expect(exitCode).toBe(0);
+    const options = extractSketchTokensMock.mock.calls[0]?.[0];
+    expect(options).toMatchObject({ filePath: path.resolve(sketchSource) });
+    const defaultOutput = path.resolve(path.join('tokens', 'brand.sketch.json'));
+    expect(writeFile).toHaveBeenCalledWith(defaultOutput, expect.any(String), 'utf8');
+  });
+
+  it('reports unexpected Sketch extraction failures', async () => {
+    const io = createMemoryCliIo();
+    const kernel = createCliKernel({ ...kernelOptions, io });
+
+    kernel.register(extractCommandModule);
+
+    extractSketchTokensMock.mockRejectedValue(new Error('sketch parse error'));
+
+    const exitCode = await kernel.run([
+      'node',
+      'dtifx',
+      'extract',
+      'sketch',
+      '--file',
+      'design.sketch',
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(io.stderrBuffer).toContain('Failed to extract Sketch tokens: Error: sketch parse error');
   });
 });

--- a/packages/cli/src/tools/extract/run-extract-cli.spec.ts
+++ b/packages/cli/src/tools/extract/run-extract-cli.spec.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { extractCommandModule } from './extract-command-module.js';
+import { createExtractCliKernel, runExtractCli } from './run-extract-cli.js';
+
+const createCliKernelMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../kernel/cli-kernel.js', () => ({
+  createCliKernel: createCliKernelMock,
+}));
+
+describe('extract CLI entrypoints', () => {
+  beforeEach(() => {
+    createCliKernelMock.mockReset();
+  });
+
+  it('registers the extract command module when creating kernels', () => {
+    const kernel = { register: vi.fn(), run: vi.fn() };
+    createCliKernelMock.mockReturnValue(kernel);
+
+    const result = createExtractCliKernel({ programName: 'dtifx', version: '0.0.0-test' });
+
+    expect(createCliKernelMock).toHaveBeenCalledWith({
+      programName: 'dtifx',
+      version: '0.0.0-test',
+    });
+    expect(kernel.register).toHaveBeenCalledWith(extractCommandModule);
+    expect(result).toBe(kernel);
+  });
+
+  it('runs the CLI kernel with provided arguments', async () => {
+    const run = vi.fn().mockResolvedValue(42);
+    const kernel = { register: vi.fn(), run };
+    createCliKernelMock.mockReturnValue(kernel);
+
+    const exitCode = await runExtractCli({
+      argv: ['node', 'dtifx', 'extract', '--help'],
+      programName: 'dtifx',
+      version: '1.2.3',
+      description: 'Extract tokens',
+    });
+
+    expect(createCliKernelMock).toHaveBeenCalledWith({
+      programName: 'dtifx',
+      version: '1.2.3',
+      description: 'Extract tokens',
+      io: undefined,
+    });
+    expect(run).toHaveBeenCalledWith(['node', 'dtifx', 'extract', '--help']);
+    expect(exitCode).toBe(42);
+  });
+});

--- a/packages/cli/src/tools/init/scaffold.spec.ts
+++ b/packages/cli/src/tools/init/scaffold.spec.ts
@@ -1,118 +1,237 @@
-import { mkdtemp, readFile, readdir, rm, stat, writeFile, mkdir } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createMemoryCliIo } from '../../testing/memory-cli-io.js';
-import { scaffoldWorkspace } from './scaffold.js';
+
+type SpawnMock = ReturnType<typeof vi.fn>;
+
+const spawnMock: SpawnMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+}));
+
+const scaffoldModulePromise = import('./scaffold.js');
+
+// eslint-disable-next-line unicorn/prefer-event-target -- child processes implement the EventEmitter contract
+class MockChildProcess extends EventEmitter {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+}
+
+const createMockSpawn = (options: {
+  readonly code: number;
+  readonly stdout?: readonly string[];
+  readonly stderr?: readonly string[];
+}): MockChildProcess => {
+  const child = new MockChildProcess();
+  queueMicrotask(() => {
+    for (const chunk of options.stdout ?? []) {
+      child.stdout.emit('data', chunk);
+    }
+    for (const chunk of options.stderr ?? []) {
+      child.stderr.emit('data', chunk);
+    }
+    child.emit('close', options.code);
+  });
+  return child;
+};
+
+const createTemplateRoot = async (): Promise<string> => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'dtifx-cli-template-'));
+  await mkdir(path.join(root, 'base', 'nested'), { recursive: true });
+  await writeFile(
+    path.join(root, 'base', 'README.md.template'),
+    '# __PROJECT_NAME__ using __PACKAGE_MANAGER_TAG__',
+    'utf8',
+  );
+  await writeFile(
+    path.join(root, 'base', 'config.json.template'),
+    '{"name":"__PACKAGE_NAME__"}',
+    'utf8',
+  );
+  await writeFile(path.join(root, 'base', 'plain.txt'), 'Plain content', 'utf8');
+  await writeFile(
+    path.join(root, 'base', 'nested', 'note.template'),
+    'Nested __PROJECT_NAME__',
+    'utf8',
+  );
+  await mkdir(path.join(root, 'sample-data'), { recursive: true });
+  await writeFile(path.join(root, 'sample-data', 'example.txt'), 'Sample content', 'utf8');
+  return root;
+};
 
 describe('scaffoldWorkspace', () => {
-  const templateRoot = fileURLToPath(new URL('../../../templates', import.meta.url));
+  let templateRoot: string;
   let workspaceRoot: string;
 
   beforeEach(async () => {
-    workspaceRoot = await mkdtemp(path.join(tmpdir(), 'dtifx-init-'));
+    templateRoot = await createTemplateRoot();
+    workspaceRoot = await mkdtemp(path.join(os.tmpdir(), 'dtifx-cli-workspace-'));
+    spawnMock.mockReset();
   });
 
   afterEach(async () => {
+    await rm(templateRoot, { recursive: true, force: true });
     await rm(workspaceRoot, { recursive: true, force: true });
   });
 
-  it('copies templates, installs dependencies, and initialises git', async () => {
-    const destination = path.join(workspaceRoot, 'demo-project');
-    const commands: Array<{ command: string; args: readonly string[]; cwd: string }> = [];
+  it('renders templates, installs dependencies, and initialises git', async () => {
+    const { scaffoldWorkspace } = await scaffoldModulePromise;
+    const destination = path.join(workspaceRoot, 'project');
     const io = createMemoryCliIo();
+    const commands: string[] = [];
 
     await scaffoldWorkspace({
       metadata: {
-        name: 'demo-project',
-        displayName: 'Demo Project',
+        name: 'cli-app',
+        displayName: 'CLI App',
         packageManager: 'pnpm',
         includeSampleData: true,
         initializeGit: true,
         destination,
       },
       io,
-      runCommand: async (command, args, options) => {
-        commands.push({ command, args, cwd: options.cwd });
-      },
       templateRoot,
+      async runCommand(command, args) {
+        commands.push([command, ...args].join(' '));
+      },
     });
 
-    const files = await readdir(destination);
-    expect(files).toEqual(
-      expect.arrayContaining(['README.md', 'package.json', 'dtifx.config.mjs']),
-    );
-
-    const packageManifest = JSON.parse(
-      await readFile(path.join(destination, 'package.json'), 'utf8'),
-    ) as {
-      readonly name: string;
-      readonly packageManager: string;
-    };
-    expect(packageManifest.name).toBe('demo-project');
-    expect(packageManifest.packageManager).toContain('pnpm');
-
     const readme = await readFile(path.join(destination, 'README.md'), 'utf8');
-    expect(readme).toContain('Demo Project');
+    expect(readme).toContain('# CLI App using pnpm@9');
 
-    await expect(stat(path.join(destination, 'tokens', 'foundation.json'))).resolves.toBeDefined();
-    await expect(stat(path.join(destination, 'tokens', 'product.json'))).resolves.toBeDefined();
+    const config = await readFile(path.join(destination, 'config.json'), 'utf8');
+    expect(config).toBe('{"name":"cli-app"}');
 
-    expect(commands).toEqual([
-      { command: 'pnpm', args: ['install'], cwd: destination },
-      { command: 'git', args: ['init'], cwd: destination },
-    ]);
+    const sampleData = await readFile(path.join(destination, 'example.txt'), 'utf8');
+    expect(sampleData).toBe('Sample content');
+
+    const nested = await readFile(path.join(destination, 'nested', 'note'), 'utf8');
+    expect(nested).toBe('Nested CLI App');
+
+    const plain = await readFile(path.join(destination, 'plain.txt'), 'utf8');
+    expect(plain).toBe('Plain content');
+
+    expect(commands).toEqual(['pnpm install', 'git init']);
     expect(io.stdoutBuffer).toContain('Scaffolding DTIFx workspace');
     expect(io.stdoutBuffer).toContain('DTIFx workspace ready');
   });
 
-  it('skips sample data when requested', async () => {
-    const destination = path.join(workspaceRoot, 'minimal');
+  it('wraps dependency installation failures with helpful context', async () => {
+    const { scaffoldWorkspace } = await scaffoldModulePromise;
+    const destination = path.join(workspaceRoot, 'fails');
     const io = createMemoryCliIo();
 
-    await scaffoldWorkspace({
-      metadata: {
-        name: 'minimal',
-        displayName: 'Minimal',
-        packageManager: 'npm',
-        includeSampleData: false,
-        initializeGit: false,
-        destination,
-      },
-      io,
-      runCommand: async () => {},
-      templateRoot,
-    });
-
-    await expect(stat(path.join(destination, 'tokens', 'foundation.json'))).rejects.toThrow();
-    const tokenEntries = await readdir(path.join(destination, 'tokens'));
-    expect(tokenEntries).toEqual(expect.arrayContaining(['README.md']));
-  });
-
-  it('throws when the destination is not empty', async () => {
-    const destination = path.join(workspaceRoot, 'existing');
-    await mkdir(destination, { recursive: true });
-    await writeFile(path.join(destination, 'README.md'), '# Existing');
-
-    const io = createMemoryCliIo();
+    spawnMock.mockImplementationOnce(() =>
+      createMockSpawn({ code: 1, stderr: ['permission denied'] }),
+    );
 
     await expect(
       scaffoldWorkspace({
         metadata: {
-          name: 'existing',
-          displayName: 'Existing',
+          name: 'cli-app',
+          displayName: 'CLI App',
           packageManager: 'pnpm',
           includeSampleData: false,
           initializeGit: false,
           destination,
         },
         io,
-        runCommand: async () => {},
         templateRoot,
       }),
-    ).rejects.toThrow('is not empty');
+    ).rejects.toThrow(/Failed to install dependencies/);
+
+    expect(io.stderrBuffer).toContain('permission denied');
+    expect(spawnMock).toHaveBeenCalledWith(
+      'pnpm',
+      ['install'],
+      expect.objectContaining({ cwd: destination }),
+    );
+  });
+
+  it('streams default run command output on success', async () => {
+    const { scaffoldWorkspace } = await scaffoldModulePromise;
+    const destination = path.join(workspaceRoot, 'default-success');
+    const io = createMemoryCliIo();
+
+    spawnMock.mockImplementationOnce(() =>
+      createMockSpawn({ code: 0, stdout: ['install ok'], stderr: ['minor warning'] }),
+    );
+
+    await scaffoldWorkspace({
+      metadata: {
+        name: 'cli-app',
+        displayName: 'CLI App',
+        packageManager: 'pnpm',
+        includeSampleData: false,
+        initializeGit: false,
+        destination,
+      },
+      io,
+      templateRoot,
+    });
+
+    expect(io.stdoutBuffer).toContain('install ok');
+    expect(io.stderrBuffer).toContain('minor warning');
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps git initialisation failures with helpful context', async () => {
+    const { scaffoldWorkspace } = await scaffoldModulePromise;
+    const destination = path.join(workspaceRoot, 'git-failure');
+    const io = createMemoryCliIo();
+
+    await expect(
+      scaffoldWorkspace({
+        metadata: {
+          name: 'cli-app',
+          displayName: 'CLI App',
+          packageManager: 'pnpm',
+          includeSampleData: false,
+          initializeGit: true,
+          destination,
+        },
+        io,
+        templateRoot,
+        async runCommand(command, args) {
+          if (command === 'git') {
+            throw new Error('git not available');
+          }
+          if (command === 'pnpm') {
+            return;
+          }
+          throw new Error(`Unexpected command ${command} ${args.join(' ')}`);
+        },
+      }),
+    ).rejects.toThrow(/Failed to initialise Git repository/);
+  });
+
+  it('fails fast when destination directory is not empty', async () => {
+    const { scaffoldWorkspace } = await scaffoldModulePromise;
+    const destination = path.join(workspaceRoot, 'existing');
+    await mkdir(destination, { recursive: true });
+    await writeFile(path.join(destination, 'file.txt'), 'existing', 'utf8');
+    const io = createMemoryCliIo();
+
+    await expect(
+      scaffoldWorkspace({
+        metadata: {
+          name: 'cli-app',
+          displayName: 'CLI App',
+          packageManager: 'pnpm',
+          includeSampleData: false,
+          initializeGit: false,
+          destination,
+        },
+        io,
+        templateRoot,
+      }),
+    ).rejects.toThrow(/Destination .* is not empty/);
   });
 });

--- a/packages/cli/src/utils/format-cli-error.spec.ts
+++ b/packages/cli/src/utils/format-cli-error.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatCliError } from './format-cli-error.js';
+
+describe('formatCliError', () => {
+  it('prefers stack traces from Error instances', () => {
+    const error = new Error('boom');
+    error.stack = 'Captured stack trace';
+
+    expect(formatCliError(error)).toBe('Captured stack trace');
+  });
+
+  it('returns error messages when stack traces are unavailable', () => {
+    const error = new Error('missing stack');
+    error.stack = undefined;
+
+    expect(formatCliError(error)).toBe('missing stack');
+  });
+
+  it('returns string errors as-is', () => {
+    expect(formatCliError('plain error')).toBe('plain error');
+  });
+
+  it('inspects non-error values for debugging context', () => {
+    const diagnostic = { reason: 'validation failed', details: { field: 'name', code: 422 } };
+
+    expect(formatCliError(diagnostic)).toContain("reason: 'validation failed'");
+    expect(formatCliError(diagnostic)).toContain("field: 'name'");
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive tests for CLI process IO, public API exports, and shared testing utilities
- introduce audit module importer override for tests and expand build module coverage scenarios
- exercise init scaffolding, audit runner, diff helpers, and extract CLI integrations to cover error handling branches

## Testing
- pnpm lint
- pnpm lint:markdown
- pnpm build
- pnpm test
- pnpm format:check
- CI=1 pnpm docs:build
- pnpm nx test cli -- --coverage --skip-nx-cache

------
https://chatgpt.com/codex/tasks/task_e_68fcb11c49f483288bf31ac715f65886