### PR TITLE
chore: upgrade eslint-plugin-unicorn

### DIFF
--- a/.changeset/fix-unicorn-followups.md
+++ b/.changeset/fix-unicorn-followups.md
@@ -1,0 +1,5 @@
+---
+'@dtifx/build': patch
+---
+
+resolve unicorn immutability lint failures across build formatters and tests

--- a/.changeset/upgrade-unicorn-linting.md
+++ b/.changeset/upgrade-unicorn-linting.md
@@ -1,0 +1,7 @@
+---
+'@dtifx/audit': patch
+'@dtifx/build': patch
+'@dtifx/core': patch
+---
+
+Align parser metrics consumers with eslint-plugin-unicorn 62's stricter rules.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-jsdoc": "61.1.8",
     "eslint-plugin-prettier": "5.5.4",
-    "eslint-plugin-unicorn": "61.0.2",
+    "eslint-plugin-unicorn": "62.0.0",
     "husky": "9.1.7",
     "lint-staged": "16.2.6",
     "markdownlint-cli": "0.45.0",

--- a/packages/audit/src/application/runtime/audit-token-resolution-environment.ts
+++ b/packages/audit/src/application/runtime/audit-token-resolution-environment.ts
@@ -366,12 +366,14 @@ function toPolicyTokenMetadata(snapshot: TokenResolutionSnapshot): PolicyTokenMe
   } satisfies PolicyTokenMetadata;
 }
 
+const defaultParserMetricsConsumer: () => ParserMetrics | undefined = () => {};
+
 function createParserMetricsConsumer(parser: ParserPort): () => ParserMetrics | undefined {
   const candidate = parser as ParserPort & { consumeMetrics?: () => ParserMetrics | undefined };
   if (typeof candidate.consumeMetrics === 'function') {
-    return () => candidate.consumeMetrics?.();
+    return candidate.consumeMetrics.bind(candidate);
   }
-  return () => void 0;
+  return defaultParserMetricsConsumer;
 }
 
 function toTokenMetricsSnapshot(snapshot: TokenResolutionSnapshot): TokenMetricsSnapshot {

--- a/packages/audit/src/application/runtime/audit-token-resolution-environment.ts
+++ b/packages/audit/src/application/runtime/audit-token-resolution-environment.ts
@@ -366,7 +366,9 @@ function toPolicyTokenMetadata(snapshot: TokenResolutionSnapshot): PolicyTokenMe
   } satisfies PolicyTokenMetadata;
 }
 
-const defaultParserMetricsConsumer: () => ParserMetrics | undefined = () => {};
+function defaultParserMetricsConsumer(): ParserMetrics | undefined {
+  return;
+}
 
 function createParserMetricsConsumer(parser: ParserPort): () => ParserMetrics | undefined {
   const candidate = parser as ParserPort & { consumeMetrics?: () => ParserMetrics | undefined };

--- a/packages/build/src/application/build-runtime.integration.spec.ts
+++ b/packages/build/src/application/build-runtime.integration.spec.ts
@@ -25,9 +25,9 @@ class MemoryDependencyCache implements TokenDependencyCache {
 
   async evaluate(snapshot: TokenDependencySnapshot): Promise<TokenDependencyDiff> {
     this.evaluations.push(snapshot);
-    const previousEntries = new Map(
-      this.previous?.entries.map((entry) => [entry.pointer, entry]) ?? [],
-    );
+    const previousEntries = this.previous
+      ? new Map(this.previous.entries.map((entry) => [entry.pointer, entry]))
+      : new Map();
     const changed = new Set<string>();
     const removed = new Set<string>();
 

--- a/packages/build/src/formatter/formatter-registry.ts
+++ b/packages/build/src/formatter/formatter-registry.ts
@@ -291,9 +291,7 @@ function groupTransformResults(
       pointerTransforms.set(result.transform, result.output);
       continue;
     }
-    const map = new Map<string, unknown>();
-    map.set(result.transform, result.output);
-    grouped.set(result.pointer, map);
+    grouped.set(result.pointer, new Map<string, unknown>([[result.transform, result.output]]));
   }
-  return new Map([...grouped.entries()].map(([pointer, map]) => [pointer, new Map(map.entries())]));
+  return new Map([...grouped.entries()].map(([pointer, map]) => [pointer, new Map(map)]));
 }

--- a/packages/build/src/infrastructure/formatting/android-compose-typography-formatter.ts
+++ b/packages/build/src/infrastructure/formatting/android-compose-typography-formatter.ts
@@ -158,21 +158,18 @@ function formatComposeTypography(
   const usesSp = entries.some((entry) => usesSpUnits(entry.metadata));
   const usesEm = entries.some((entry) => usesEmUnits(entry.metadata));
 
-  const importLines = new Set<string>();
-  importLines.add('import androidx.compose.ui.text.TextStyle');
-  if (usesFontFamily) {
-    importLines.add('import androidx.compose.ui.text.font.Font');
-    importLines.add('import androidx.compose.ui.text.font.FontFamily');
-  }
-  if (usesFontWeight) {
-    importLines.add('import androidx.compose.ui.text.font.FontWeight');
-  }
-  if (usesSp) {
-    importLines.add('import androidx.compose.ui.unit.sp');
-  }
-  if (usesEm) {
-    importLines.add('import androidx.compose.ui.unit.em');
-  }
+  const importLines = new Set<string>([
+    'import androidx.compose.ui.text.TextStyle',
+    ...(usesFontFamily
+      ? [
+          'import androidx.compose.ui.text.font.Font',
+          'import androidx.compose.ui.text.font.FontFamily',
+        ]
+      : []),
+    ...(usesFontWeight ? ['import androidx.compose.ui.text.font.FontWeight'] : []),
+    ...(usesSp ? ['import androidx.compose.ui.unit.sp'] : []),
+    ...(usesEm ? ['import androidx.compose.ui.unit.em'] : []),
+  ]);
 
   const blocks = entries.map((entry) => formatTypographyEntry(entry));
 

--- a/packages/build/src/infrastructure/formatting/android-material-typography-formatter.ts
+++ b/packages/build/src/infrastructure/formatting/android-material-typography-formatter.ts
@@ -170,18 +170,13 @@ function formatTypographyResources(
   const usesEm = entries.some((entry) => usesEmUnits(entry.metadata));
   const usesDp = entries.some((entry) => usesDpUnits(entry.metadata));
 
-  const importLines = new Set<string>();
-  importLines.add('import androidx.compose.ui.unit.Dp');
-  importLines.add('import androidx.compose.ui.unit.TextUnit');
-  if (usesDp) {
-    importLines.add('import androidx.compose.ui.unit.dp');
-  }
-  if (usesSp) {
-    importLines.add('import androidx.compose.ui.unit.sp');
-  }
-  if (usesEm) {
-    importLines.add('import androidx.compose.ui.unit.em');
-  }
+  const importLines = new Set<string>([
+    'import androidx.compose.ui.unit.Dp',
+    'import androidx.compose.ui.unit.TextUnit',
+    ...(usesDp ? ['import androidx.compose.ui.unit.dp'] : []),
+    ...(usesSp ? ['import androidx.compose.ui.unit.sp'] : []),
+    ...(usesEm ? ['import androidx.compose.ui.unit.em'] : []),
+  ]);
 
   const blocks = entries.map((entry) => formatTypographyEntry(entry, options.dataClassName));
 

--- a/packages/build/src/infrastructure/formatting/ios-swiftui-gradients-formatter.ts
+++ b/packages/build/src/infrastructure/formatting/ios-swiftui-gradients-formatter.ts
@@ -235,40 +235,29 @@ function formatGradient(metadata: GradientSwiftUiTransformOutput): readonly stri
     );
   }
 
-  const lines: string[] = ['GradientToken('];
-  lines.push(`    kind: .${metadata.kind},`);
+  const header = [
+    'GradientToken(',
+    `    kind: .${metadata.kind},`,
+    ...(metadata.angle === undefined ? [] : [`    angle: ${formatNumber(metadata.angle)},`]),
+    '    stops: [',
+  ];
 
-  if (metadata.angle !== undefined) {
-    lines.push(`    angle: ${formatNumber(metadata.angle)},`);
-  }
+  const stopLines = metadata.stops.flatMap((stop) => {
+    const lines = formatGradientStop(stop);
+    return lines.map((line, index) => (index === lines.length - 1 ? `${line},` : line));
+  });
 
-  lines.push('    stops: [');
-
-  for (const stop of metadata.stops) {
-    const stopLines = formatGradientStop(stop);
-    const formattedStopLines = stopLines.map((line, index) =>
-      index === stopLines.length - 1 ? `${line},` : line,
-    );
-    lines.push(...formattedStopLines);
-  }
-
-  lines.push('    ]', '  )');
-
-  return lines;
+  return [...header, ...stopLines, '    ]', '  )'];
 }
 
 function formatGradientStop(
   stop: GradientSwiftUiTransformOutput['stops'][number],
 ): readonly string[] {
-  const argumentsList = [`color: "${escapeString(stop.color)}"`];
-
-  if (stop.location !== undefined) {
-    argumentsList.push(`location: ${formatNumber(stop.location)}`);
-  }
-
-  if (stop.easing !== undefined) {
-    argumentsList.push(`easing: "${escapeString(stop.easing)}"`);
-  }
+  const argumentsList = [
+    `color: "${escapeString(stop.color)}"`,
+    ...(stop.location === undefined ? [] : [`location: ${formatNumber(stop.location)}`]),
+    ...(stop.easing === undefined ? [] : [`easing: "${escapeString(stop.easing)}"`]),
+  ];
 
   if (argumentsList.length === 1) {
     return [`      GradientStop(${argumentsList[0]!})`];

--- a/packages/build/src/infrastructure/formatting/ios-swiftui-shadows-formatter.ts
+++ b/packages/build/src/infrastructure/formatting/ios-swiftui-shadows-formatter.ts
@@ -239,20 +239,14 @@ function formatShadow(metadata: ShadowSwiftUiTransformOutput): readonly string[]
     return [];
   }
 
-  const lines: string[] = ['ShadowToken('];
-  lines.push('    layers: [');
+  const header = ['ShadowToken(', '    layers: ['];
 
-  for (const layer of metadata.layers) {
-    const layerLines = formatShadowLayer(layer);
-    const formattedLayerLines = layerLines.map((line, index) =>
-      index === layerLines.length - 1 ? `${line},` : line,
-    );
-    lines.push(...formattedLayerLines);
-  }
+  const layerLines = metadata.layers.flatMap((layer) => {
+    const lines = formatShadowLayer(layer);
+    return lines.map((line, index) => (index === lines.length - 1 ? `${line},` : line));
+  });
 
-  lines.push('    ]', '  )');
-
-  return lines;
+  return [...header, ...layerLines, '    ]', '  )'];
 }
 
 function formatShadowLayer(
@@ -263,15 +257,9 @@ function formatShadowLayer(
     `x: ${formatNumber(layer.x)}`,
     `y: ${formatNumber(layer.y)}`,
     `radius: ${formatNumber(layer.radius)}`,
+    ...(layer.spread === undefined ? [] : [`spread: ${formatNumber(layer.spread)}`]),
+    ...(layer.opacity === undefined ? [] : [`opacity: ${formatNumber(layer.opacity)}`]),
   ];
-
-  if (layer.spread !== undefined) {
-    argumentsList.push(`spread: ${formatNumber(layer.spread)}`);
-  }
-
-  if (layer.opacity !== undefined) {
-    argumentsList.push(`opacity: ${formatNumber(layer.opacity)}`);
-  }
 
   if (argumentsList.length === 4) {
     return [`      ShadowLayer(${argumentsList.join(', ')})`];

--- a/packages/build/src/session/resolution-session.ts
+++ b/packages/build/src/session/resolution-session.ts
@@ -39,7 +39,9 @@ export interface ResolutionSessionOptions {
   readonly eventBus?: DomainEventBusPort;
 }
 
-const defaultParserMetricsConsumer: () => ParserMetrics | undefined = () => {};
+function defaultParserMetricsConsumer(): ParserMetrics | undefined {
+  return;
+}
 
 export class ResolutionSession {
   private readonly service: TokenResolutionService;

--- a/packages/build/src/session/resolution-session.ts
+++ b/packages/build/src/session/resolution-session.ts
@@ -39,6 +39,8 @@ export interface ResolutionSessionOptions {
   readonly eventBus?: DomainEventBusPort;
 }
 
+const defaultParserMetricsConsumer: () => ParserMetrics | undefined = () => {};
+
 export class ResolutionSession {
   private readonly service: TokenResolutionService;
   private readonly consumeMetricsFn: () => ParserMetrics | undefined;
@@ -83,15 +85,15 @@ export class ResolutionSession {
     service: TokenResolutionService,
   ): () => ParserMetrics | undefined {
     if (typeof service.consumeMetrics === 'function') {
-      return () => service.consumeMetrics();
+      return service.consumeMetrics.bind(service);
     }
 
     const candidate = parser as ParserPort & {
       readonly consumeMetrics?: () => ParserMetrics | undefined;
     };
     if (typeof candidate.consumeMetrics === 'function') {
-      return () => candidate.consumeMetrics?.();
+      return candidate.consumeMetrics.bind(candidate);
     }
-    return () => undefined as ParserMetrics | undefined;
+    return defaultParserMetricsConsumer;
   }
 }

--- a/packages/build/src/transform/gradient-transforms.spec.ts
+++ b/packages/build/src/transform/gradient-transforms.spec.ts
@@ -8,12 +8,11 @@ import {
 } from './gradient-transforms.js';
 
 function createSnapshot(pointer: string, value: unknown, resolved?: unknown): TokenSnapshot {
-  const snapshot: Record<string, unknown> = { pointer };
-  snapshot.value = value;
-  if (resolved !== undefined) {
-    snapshot.resolution = { value: resolved };
-  }
-  return snapshot as TokenSnapshot;
+  return {
+    pointer,
+    value,
+    ...(resolved === undefined ? {} : { resolution: { value: resolved } }),
+  } as TokenSnapshot;
 }
 
 function createSrgbColor(hex: string) {

--- a/packages/core/src/prefabs/image.ts
+++ b/packages/core/src/prefabs/image.ts
@@ -53,20 +53,12 @@ export class ImageTokenPrefab extends TokenPrefab<ImageValue, ImageTokenPrefab> 
     options: Omit<ImageOptions, 'sources'> & ResponsiveImageOptions = {},
   ): ImageTokenPrefab {
     const sources = buildResponsiveSources(base, options);
-    const createOptions: Mutable<Partial<ImageOptions>> = {};
-    createOptions.sources = sources;
-
-    if (options.imageType !== undefined) {
-      createOptions.imageType = options.imageType;
-    }
-
-    if (options.alt !== undefined) {
-      createOptions.alt = options.alt;
-    }
-
-    if (options.placeholder !== undefined) {
-      createOptions.placeholder = options.placeholder;
-    }
+    const createOptions: Mutable<Partial<ImageOptions>> = {
+      sources,
+      ...(options.imageType === undefined ? {} : { imageType: options.imageType }),
+      ...(options.alt === undefined ? {} : { alt: options.alt }),
+      ...(options.placeholder === undefined ? {} : { placeholder: options.placeholder }),
+    };
 
     return ImageTokenPrefab.create(path, createOptions as ImageOptions);
   }

--- a/packages/core/src/prefabs/media-query.ts
+++ b/packages/core/src/prefabs/media-query.ts
@@ -74,12 +74,10 @@ export class MediaQueryTokenPrefab extends TokenPrefab<MediaQueryValue, MediaQue
       throw new TypeError('Width range prefabs require at least a min or max value.');
     }
 
-    const createOptions: Mutable<Partial<MediaQueryOptions>> = {};
-    createOptions.constraints = constraints;
-
-    if (options.mediaType !== undefined) {
-      createOptions.mediaType = options.mediaType;
-    }
+    const createOptions: Mutable<Partial<MediaQueryOptions>> = {
+      constraints,
+      ...(options.mediaType === undefined ? {} : { mediaType: options.mediaType }),
+    };
 
     return MediaQueryTokenPrefab.create(path, createOptions as MediaQueryOptions);
   }

--- a/packages/core/src/sources/token-resolution-service.ts
+++ b/packages/core/src/sources/token-resolution-service.ts
@@ -104,7 +104,7 @@ export class TokenResolutionService {
       readonly consumeMetrics?: () => ParserMetrics | undefined;
     };
     if (typeof candidate.consumeMetrics === 'function') {
-      return () => candidate.consumeMetrics?.();
+      return candidate.consumeMetrics.bind(candidate);
     }
 
     return undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: 5.5.4
         version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))(prettier@3.6.2)
       eslint-plugin-unicorn:
-        specifier: 61.0.2
-        version: 61.0.2(eslint@9.38.0(jiti@2.6.1))
+        specifier: 62.0.0
+        version: 62.0.0(eslint@9.38.0(jiti@2.6.1))
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -439,6 +439,10 @@ packages:
 
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -1367,10 +1371,6 @@ packages:
     resolution: {integrity: sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/core@0.15.2':
-    resolution: {integrity: sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@eslint/core@0.16.0':
     resolution: {integrity: sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1385,10 +1385,6 @@ packages:
 
   '@eslint/object-schema@2.1.7':
     resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/plugin-kit@0.3.5':
-    resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/plugin-kit@0.4.0':
@@ -2768,11 +2764,11 @@ packages:
       eslint-config-prettier:
         optional: true
 
-  eslint-plugin-unicorn@61.0.2:
-    resolution: {integrity: sha512-zLihukvneYT7f74GNbVJXfWIiNQmkc/a9vYBTE4qPkQZswolWNdu+Wsp9sIXno1JOzdn6OUwLPd19ekXVkahRA==}
+  eslint-plugin-unicorn@62.0.0:
+    resolution: {integrity: sha512-HIlIkGLkvf29YEiS/ImuDZQbP12gWyx5i3C6XrRxMvVdqMroCI9qoVYCoIl17ChN+U89pn9sVwLxhIWj5nEc7g==}
     engines: {node: ^20.10.0 || >=21.0.0}
     peerDependencies:
-      eslint: '>=9.29.0'
+      eslint: '>=9.38.0'
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -3399,11 +3395,6 @@ packages:
   jsep@1.4.0:
     resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
     engines: {node: '>= 10.16.0'}
-
-  jsesc@3.0.2:
-    resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
-    engines: {node: '>=6'}
-    hasBin: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -4079,10 +4070,6 @@ packages:
   regjsgen@0.8.0:
     resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
 
-  regjsparser@0.12.0:
-    resolution: {integrity: sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==}
-    hasBin: true
-
   regjsparser@0.13.0:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
     hasBin: true
@@ -4342,8 +4329,8 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
-  strip-indent@4.1.0:
-    resolution: {integrity: sha512-OA95x+JPmL7kc7zCu+e+TeYxEiaIyndRx0OrBcK2QPPH09oAndr2ALvymxWA+Lx1PYYvFUm4O63pRkdJAaW96w==}
+  strip-indent@4.1.1:
+    resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
     engines: {node: '>=12'}
 
   strip-json-comments@3.1.1:
@@ -5044,6 +5031,8 @@ snapshots:
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -6087,10 +6076,6 @@ snapshots:
     dependencies:
       '@eslint/core': 0.16.0
 
-  '@eslint/core@0.15.2':
-    dependencies:
-      '@types/json-schema': 7.0.15
-
   '@eslint/core@0.16.0':
     dependencies:
       '@types/json-schema': 7.0.15
@@ -6112,11 +6097,6 @@ snapshots:
   '@eslint/js@9.38.0': {}
 
   '@eslint/object-schema@2.1.7': {}
-
-  '@eslint/plugin-kit@0.3.5':
-    dependencies:
-      '@eslint/core': 0.15.2
-      levn: 0.4.1
 
   '@eslint/plugin-kit@0.4.0':
     dependencies:
@@ -7717,11 +7697,11 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@9.38.0(jiti@2.6.1))
 
-  eslint-plugin-unicorn@61.0.2(eslint@9.38.0(jiti@2.6.1)):
+  eslint-plugin-unicorn@62.0.0(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.6.1))
-      '@eslint/plugin-kit': 0.3.5
+      '@eslint/plugin-kit': 0.4.0
       change-case: 5.4.4
       ci-info: 4.3.1
       clean-regexp: 1.0.0
@@ -7735,9 +7715,9 @@ snapshots:
       jsesc: 3.1.0
       pluralize: 8.0.0
       regexp-tree: 0.1.27
-      regjsparser: 0.12.0
+      regjsparser: 0.13.0
       semver: 7.7.3
-      strip-indent: 4.1.0
+      strip-indent: 4.1.1
 
   eslint-scope@8.4.0:
     dependencies:
@@ -8365,8 +8345,6 @@ snapshots:
   jsdoc-type-pratt-parser@6.10.0: {}
 
   jsep@1.4.0: {}
-
-  jsesc@3.0.2: {}
 
   jsesc@3.1.0: {}
 
@@ -9192,10 +9170,6 @@ snapshots:
 
   regjsgen@0.8.0: {}
 
-  regjsparser@0.12.0:
-    dependencies:
-      jsesc: 3.0.2
-
   regjsparser@0.13.0:
     dependencies:
       jsesc: 3.1.0
@@ -9497,7 +9471,7 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  strip-indent@4.1.0: {}
+  strip-indent@4.1.1: {}
 
   strip-json-comments@3.1.1: {}
 


### PR DESCRIPTION
## Summary
- upgrade eslint-plugin-unicorn to v62.0.0 and refresh the lockfile
- update parser metrics consumers to return bound callables that satisfy new unicorn rules
- initialize prefab option objects without immediate mutation and add a patch changeset

## Testing
- NX_OUTPUT_STYLE=static pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68fe0a1a2f3883289a2b3a9fb943901d