### PR TITLE
Fix docs workflow concurrency to avoid PR cancellations

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- scope the Pages concurrency group to the branch or pull request so documentation builds are not cancelled by unrelated runs

## Testing
- CI=1 pnpm lint
- CI=1 pnpm lint:markdown
- CI=1 pnpm build
- CI=1 pnpm test -- --run
- CI=1 pnpm format:check
- CI=1 pnpm docs:build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691877516630832883fc11baa7914416)