### PR TITLE
Adopt Nx Vitest executor

### DIFF
--- a/.changeset/use-nx-vitest-executor.md
+++ b/.changeset/use-nx-vitest-executor.md
@@ -1,0 +1,10 @@
+---
+'@dtifx/audit': patch
+'@dtifx/build': patch
+'@dtifx/cli': patch
+'@dtifx/core': patch
+'@dtifx/diff': patch
+'@dtifx/extractors': patch
+---
+
+Switch Vite Vitest targets to the new Nx Vitest executor.

--- a/nx.json
+++ b/nx.json
@@ -43,5 +43,5 @@
   "tui": {
     "enabled": false
   },
-  "plugins": ["@nx/js", "@nx/vite"]
+  "plugins": ["@nx/js", "@nx/vite", "@nx/vitest"]
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@nx/eslint": "22.1.0",
     "@nx/eslint-plugin": "22.1.0",
     "@nx/js": "22.1.0",
+    "@nx/vitest": "22.1.0",
     "@nx/vite": "22.1.0",
     "@types/node": "24.10.1",
     "@typescript-eslint/eslint-plugin": "8.47.0",

--- a/packages/audit/project.json
+++ b/packages/audit/project.json
@@ -23,7 +23,7 @@
       }
     },
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "outputs": ["{projectRoot}/coverage"],
       "options": {
         "config": "packages/audit/vitest.config.ts"

--- a/packages/build/project.json
+++ b/packages/build/project.json
@@ -32,7 +32,7 @@
       }
     },
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "outputs": ["{projectRoot}/coverage"],
       "options": {
         "config": "packages/build/vitest.config.ts"

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -23,7 +23,7 @@
       }
     },
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "outputs": ["{projectRoot}/coverage"],
       "options": {
         "config": "packages/cli/vitest.config.ts"

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -22,7 +22,7 @@
       }
     },
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "outputs": ["{projectRoot}/coverage"],
       "options": {
         "config": "packages/core/vitest.config.ts"

--- a/packages/diff/project.json
+++ b/packages/diff/project.json
@@ -32,7 +32,7 @@
       }
     },
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "outputs": ["{projectRoot}/coverage"],
       "options": {
         "config": "packages/diff/vitest.config.ts"

--- a/packages/extractors/project.json
+++ b/packages/extractors/project.json
@@ -22,7 +22,7 @@
       }
     },
     "test": {
-      "executor": "@nx/vite:test",
+      "executor": "@nx/vitest:test",
       "outputs": ["{projectRoot}/coverage"],
       "options": {
         "config": "packages/extractors/vitest.config.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@nx/vite':
         specifier: 22.1.0
         version: 22.1.0(@babel/traverse@7.28.4)(nx@22.1.0)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.12(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))
+      '@nx/vitest':
+        specifier: 22.1.0
+        version: 22.1.0(@babel/traverse@7.28.4)(nx@22.1.0)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.12(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))
       '@types/node':
         specifier: 24.10.1
         version: 24.10.1


### PR DESCRIPTION
## Summary
- switch all package test targets to the new `@nx/vitest:test` executor and register the Nx Vitest plugin
- add the `@nx/vitest` workspace dependency and document the change via a changeset

## Testing
- pnpm lint
- pnpm lint:markdown
- pnpm build
- pnpm test
- pnpm format:check
- CI=1 pnpm docs:build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69204b06cfe48328a7358bea09bef98a)