### PR TITLE
Fix audit environment to honor injected factories

### DIFF
--- a/.changeset/synthetic-audit-module.md
+++ b/.changeset/synthetic-audit-module.md
@@ -1,0 +1,5 @@
+---
+'@dtifx/cli': patch
+---
+
+ensure injected audit factories skip module loading and fail fast when incomplete

--- a/packages/cli/src/tools/audit/environment.spec.ts
+++ b/packages/cli/src/tools/audit/environment.spec.ts
@@ -170,6 +170,27 @@ describe('prepareAuditEnvironment', () => {
     expect(environment?.tokens).toBe(tokens);
   });
 
+  it('returns undefined when injected factories are incomplete without loading the audit module', async () => {
+    const loadAuditModule = vi.fn(() => {
+      throw new Error('should not be called');
+    });
+
+    const options = {
+      reporter: 'human',
+      jsonLogs: false,
+      timings: false,
+    } as const;
+    const io = createMemoryCliIo();
+
+    const environment = await prepareAuditEnvironment(options, io, undefined, undefined, {
+      createTokenEnvironment: vi.fn(),
+      loadAuditModule,
+    });
+
+    expect(environment).toBeUndefined();
+    expect(loadAuditModule).not.toHaveBeenCalled();
+  });
+
   it('returns undefined when the audit module cannot be loaded', async () => {
     loadAuditModuleMock.mockImplementationOnce(async ({ io: commandIo }) => {
       commandIo.writeErr('Please install @dtifx/audit.\n');


### PR DESCRIPTION
## Summary
- wrap audit dependency overrides in a synthetic module before invoking the loader
- let the audit environment setup prefer injected factories over loading the audit package
- extend audit environment coverage and add a changeset

## Testing
- pnpm lint
- pnpm lint:markdown
- pnpm build
- pnpm test
- pnpm format:check
- CI=1 pnpm docs:build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926dc7458c48328a1efebca3f122575)