### PR TITLE
Ensure audit telemetry flushes on failures

### DIFF
--- a/.changeset/ensure-audit-telemetry-flush.md
+++ b/.changeset/ensure-audit-telemetry-flush.md
@@ -1,0 +1,5 @@
+---
+'@dtifx/cli': patch
+---
+
+ensure audit telemetry flushes and environments dispose on failures

--- a/docs/overview/telemetry.md
+++ b/docs/overview/telemetry.md
@@ -52,8 +52,9 @@ into span attributes so the telemetry payload records token counts, formatter co
 metrics, and failure conditions.
 
 Commands call `exportSpans()` before exiting to ensure spans reach the configured sink even when the
-process encounters an error. When using `watch`, spans are exported after each cycle so long-running
-sessions still flush regularly.
+process encounters an error. Audit commands also dispose their environments and flush telemetry when
+module resolution or environment preparation fails, so spans still export on early exits. When using
+`watch`, spans are exported after each cycle so long-running sessions still flush regularly.
 
 ## Diagnostics correlation
 


### PR DESCRIPTION
## Summary
- ensure the audit command always disposes prepared environments and exports telemetry even when initialization or runtime execution fails
- extend audit command tests to cover failure cleanup paths and capture telemetry flushing on rejected runs
- document the audit command’s automatic telemetry export/disposal and add a changeset for the CLI package

## Testing
- pnpm lint
- pnpm lint:markdown
- pnpm build
- pnpm test
- pnpm format:check
- CI=1 pnpm docs:build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926dc7684ac8328a01151427b33bcc4)