### PR TITLE
chore: fix lint formatting across packages

### DIFF
--- a/packages/build/src/incremental/token-dependency-cache.spec.ts
+++ b/packages/build/src/incremental/token-dependency-cache.spec.ts
@@ -13,9 +13,8 @@ const mkdir = vi.mocked(fs.mkdir);
 const readFile = vi.mocked(fs.readFile);
 const writeFile = vi.mocked(fs.writeFile);
 
-const { createTokenDependencySnapshot, FileSystemTokenDependencyCache } = await import(
-  './token-dependency-cache.js'
-);
+const { createTokenDependencySnapshot, FileSystemTokenDependencyCache } =
+  await import('./token-dependency-cache.js');
 
 describe('token dependency cache hashing', () => {
   it('produces a stable hash regardless of object key ordering', () => {

--- a/packages/build/src/infrastructure/formatting/default-formatter-executor.spec.ts
+++ b/packages/build/src/infrastructure/formatting/default-formatter-executor.spec.ts
@@ -17,9 +17,8 @@ vi.mock('../../formatter/formatter-registry.js', async (importOriginal) => {
   };
 });
 
-const registryModule = (await import(
-  '../../formatter/formatter-registry.js'
-)) as typeof FormatterRegistryModule;
+const registryModule =
+  (await import('../../formatter/formatter-registry.js')) as typeof FormatterRegistryModule;
 const mockedCreateContext = vi.mocked(registryModule.createFormatterExecutionContext);
 const mockedRunDefinition = vi.mocked(registryModule.runFormatterDefinition);
 

--- a/packages/build/src/transform/transform-registry.ts
+++ b/packages/build/src/transform/transform-registry.ts
@@ -65,9 +65,9 @@ export type { PointerPattern } from '@dtifx/core/policy/selectors';
 export interface TransformSelector<
   TType extends TokenTypeIdentifier | undefined = TokenTypeIdentifier | undefined,
 > extends TokenSelector<
-    TokenSnapshot,
-    TType extends TokenTypeIdentifier ? TType : TokenTypeIdentifier
-  > {}
+  TokenSnapshot,
+  TType extends TokenTypeIdentifier ? TType : TokenTypeIdentifier
+> {}
 
 /**
  * Resolves the union of token types represented by a transform selector.

--- a/packages/cli/src/tools/audit/audit-module-loader.ts
+++ b/packages/cli/src/tools/audit/audit-module-loader.ts
@@ -37,7 +37,7 @@ export const loadAuditModule: LoadAuditModule = async ({ io }) => {
 const isModuleNotFoundError = (error: unknown): error is NodeJS.ErrnoException =>
   Boolean(
     error &&
-      typeof error === 'object' &&
-      'code' in error &&
-      (error as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND',
+    typeof error === 'object' &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND',
   );

--- a/packages/cli/src/tools/build/build-module.spec.ts
+++ b/packages/cli/src/tools/build/build-module.spec.ts
@@ -17,9 +17,8 @@ describe('build module loaders', () => {
   });
 
   it('loads the @dtifx/build module once and reuses the cached promise', async () => {
-    const { loadBuildModule, setBuildModuleImportersForTesting } = await import(
-      './build-module.js'
-    );
+    const { loadBuildModule, setBuildModuleImportersForTesting } =
+      await import('./build-module.js');
     const buildModule = { symbol: Symbol('build') } as Awaited<ReturnType<typeof loadBuildModule>>;
     setBuildModuleImportersForTesting({ build: async () => buildModule });
     const io = createIo();
@@ -32,9 +31,8 @@ describe('build module loaders', () => {
   });
 
   it('informs users when @dtifx/build cannot be resolved', async () => {
-    const { loadBuildModule, setBuildModuleImportersForTesting } = await import(
-      './build-module.js'
-    );
+    const { loadBuildModule, setBuildModuleImportersForTesting } =
+      await import('./build-module.js');
     setBuildModuleImportersForTesting({
       build: async () => {
         const error = new Error('module not found') as NodeJS.ErrnoException;
@@ -60,9 +58,8 @@ describe('build module loaders', () => {
   });
 
   it('rethrows unexpected load errors for @dtifx/build', async () => {
-    const { loadBuildModule, setBuildModuleImportersForTesting } = await import(
-      './build-module.js'
-    );
+    const { loadBuildModule, setBuildModuleImportersForTesting } =
+      await import('./build-module.js');
     setBuildModuleImportersForTesting({
       build: async () => {
         throw new Error('unexpected failure');
@@ -74,9 +71,8 @@ describe('build module loaders', () => {
   });
 
   it('loads the @dtifx/build reporter module and caches results', async () => {
-    const { loadBuildReporterModule, setBuildModuleImportersForTesting } = await import(
-      './build-module.js'
-    );
+    const { loadBuildReporterModule, setBuildModuleImportersForTesting } =
+      await import('./build-module.js');
     const reporterModule = { reporters: true } as Awaited<
       ReturnType<typeof loadBuildReporterModule>
     >;
@@ -91,9 +87,8 @@ describe('build module loaders', () => {
   });
 
   it('reports missing reporter modules gracefully', async () => {
-    const { loadBuildReporterModule, setBuildModuleImportersForTesting } = await import(
-      './build-module.js'
-    );
+    const { loadBuildReporterModule, setBuildModuleImportersForTesting } =
+      await import('./build-module.js');
     setBuildModuleImportersForTesting({
       reporters: async () => {
         const error = new Error('module not found') as NodeJS.ErrnoException;

--- a/packages/cli/src/tools/build/build-module.ts
+++ b/packages/cli/src/tools/build/build-module.ts
@@ -52,9 +52,9 @@ export const loadBuildReporterModule = async (
 const isModuleNotFoundError = (error: unknown): error is NodeJS.ErrnoException =>
   Boolean(
     error &&
-      typeof error === 'object' &&
-      'code' in error &&
-      (error as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND',
+    typeof error === 'object' &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND',
   );
 
 export const setBuildModuleImportersForTesting = (options?: {

--- a/packages/cli/src/tools/diff/compare-command-runner.ts
+++ b/packages/cli/src/tools/diff/compare-command-runner.ts
@@ -151,9 +151,9 @@ export const executeDiffCompareCommand = async ({
 const isModuleNotFoundError = (error: unknown): error is NodeJS.ErrnoException =>
   Boolean(
     error &&
-      typeof error === 'object' &&
-      'code' in error &&
-      (error as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND',
+    typeof error === 'object' &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND',
   );
 
 export const __testing = {

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -165,8 +165,8 @@ async function resolveExportedValue<T>(candidate: T): Promise<unknown> {
 function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
   return Boolean(
     error &&
-      typeof error === 'object' &&
-      'code' in error &&
-      (error as NodeJS.ErrnoException).code === 'ENOENT',
+    typeof error === 'object' &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT',
   );
 }

--- a/packages/core/src/sources/token-resolution-service.ts
+++ b/packages/core/src/sources/token-resolution-service.ts
@@ -6,8 +6,10 @@ import type { ParserExecutionOptions, ParserMetrics, ParserPort, ParserResult } 
 import type { BuildLifecycleObserverPort, DomainEventBusPort } from '../runtime/index.js';
 import { resolveLifecycleEventBus } from '../runtime/lifecycle-event-adapter.js';
 
-export interface TokenResolutionServiceOptions
-  extends Omit<ParserExecutionOptions, 'documentCache' | 'tokenCache'> {
+export interface TokenResolutionServiceOptions extends Omit<
+  ParserExecutionOptions,
+  'documentCache' | 'tokenCache'
+> {
   readonly parser: ParserPort;
   readonly documentCache?: ParserExecutionOptions['documentCache'];
   readonly tokenCache?: ParserExecutionOptions['tokenCache'];


### PR DESCRIPTION
## Summary
- apply Prettier formatting fixes to core configuration and token resolution types
- normalize formatting in CLI audit, build, and diff utilities for lint compliance
- reformat build package specs and transform registry to satisfy style checks

## Testing
- pnpm lint
- pnpm lint:markdown
- pnpm build
- pnpm test
- pnpm format:check
- CI=1 pnpm docs:build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c26c83898832886e03aff782654df)