### PR TITLE
tests: stabilize watch-pipeline by awaiting async state transitions

### DIFF
--- a/.changeset/fix-build-watch-pipeline-flake.md
+++ b/.changeset/fix-build-watch-pipeline-flake.md
@@ -1,0 +1,5 @@
+---
+'@dtifx/build': patch
+---
+
+stabilize watch pipeline tests by waiting for async state transitions


### PR DESCRIPTION
### Motivation

- Flaky watch pipeline tests relied on `await delay(0)` to yield to async work, causing intermittent failures when state transitions had not completed.

### Description

- Add a `waitForCondition` helper to `packages/build/tests/watch-pipeline.spec.ts` to poll a predicate with timeout and replace fragile `await delay(0)` usages with targeted waits.
- Replace several `await delay(0)` calls with `await waitForCondition(...)` using predicates that check reporter events, factory requests, or success events to ensure the pipeline has progressed to the expected state.
- Add a `.changeset/fix-build-watch-pipeline-flake.md` changeset entry for `@dtifx/build` describing the stabilization change.

### Testing

- Ran the test suite with `vitest` focusing on `packages/build/tests/watch-pipeline.spec.ts` and confirmed the watcher pipeline tests completed successfully.
- All automated tests related to the modified spec passed without flakiness after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c5c68ed0832889a0f48084f0649d)