### PR TITLE
Improve CI diagnostics and reduce watch-pipeline flakiness

### DIFF
--- a/.changeset/improve-build-test-failure-logging.md
+++ b/.changeset/improve-build-test-failure-logging.md
@@ -1,0 +1,6 @@
+---
+'@dtifx/build': patch
+---
+
+improve CI diagnostics for build tests by forcing stream output and enabling coverage reporting on
+failures

--- a/.changeset/increase-build-branch-coverage.md
+++ b/.changeset/increase-build-branch-coverage.md
@@ -1,0 +1,6 @@
+---
+'@dtifx/build': patch
+---
+
+increase build package branch coverage with tests for config option validation and schema error
+mapping

--- a/.changeset/increase-watch-pipeline-timeout.md
+++ b/.changeset/increase-watch-pipeline-timeout.md
@@ -1,0 +1,5 @@
+---
+'@dtifx/build': patch
+---
+
+increase watch pipeline test polling timeout to reduce CI flakiness under load

--- a/.changeset/serialize-test-logs-in-ci.md
+++ b/.changeset/serialize-test-logs-in-ci.md
@@ -1,0 +1,6 @@
+---
+'@dtifx/build': patch
+---
+
+stabilize CI test diagnostics by removing noisy color warnings and running tests sequentially in
+stream mode

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "nx run-many -t build --all --exclude docs-site",
     "lint": "nx run-many -t lint --all --exclude docs-site",
     "lint:markdown": "nx run docs-site:lint",
-    "test": "nx run-many -t test --all",
+    "test": "nx run-many -t test --all --outputStyle=stream",
     "format": "nx format:write --all",
     "format:check": "nx format:check --all",
     "graph": "nx graph",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "nx run-many -t build --all --exclude docs-site",
     "lint": "nx run-many -t lint --all --exclude docs-site",
     "lint:markdown": "nx run docs-site:lint",
-    "test": "nx run-many -t test --all --outputStyle=stream",
+    "test": "env -u NO_COLOR nx run-many -t test --all --outputStyle=stream --parallel=1",
     "format": "nx format:write --all",
     "format:check": "nx format:check --all",
     "graph": "nx graph",

--- a/packages/build/src/config/config-options.spec.ts
+++ b/packages/build/src/config/config-options.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertAllowedKeys,
+  assertNumberOption,
+  assertPlainObject,
+  assertStringArrayOption,
+  assertStringOption,
+} from './config-options.js';
+
+describe('config-options', () => {
+  it('validates plain object options and clones the input', () => {
+    const input = { alpha: 1, beta: 'two' };
+
+    const output = assertPlainObject(input, 'formatter.alpha');
+
+    expect(output).toEqual(input);
+    expect(output).not.toBe(input);
+
+    expect(() => assertPlainObject(undefined, 'formatter.alpha')).toThrow(
+      /must be an object of key\/value pairs/i,
+    );
+    expect(() => assertPlainObject(['x'], 'formatter.alpha')).toThrow(
+      /must be an object of key\/value pairs/i,
+    );
+    expect(() => assertPlainObject('value', 'formatter.alpha')).toThrow(
+      /must be an object of key\/value pairs/i,
+    );
+  });
+
+  it('rejects unknown keys for option sets', () => {
+    expect(() =>
+      assertAllowedKeys({ enabled: true }, new Set(['enabled']), 'preview', 'formatter'),
+    ).not.toThrow();
+
+    expect(() =>
+      assertAllowedKeys({ enabled: true, extra: false }, new Set(['enabled']), 'preview', 'policy'),
+    ).toThrow('Unknown policy option "extra" supplied for "preview".');
+  });
+
+  it('validates numeric options', () => {
+    expect(assertNumberOption(42, 'cache', 'ttl')).toBe(42);
+
+    expect(() => assertNumberOption(Number.NaN, 'cache', 'ttl')).toThrow(
+      'Option "ttl" for "cache" must be a finite number. Received NaN.',
+    );
+
+    expect(() => assertNumberOption('42', 'cache', 'ttl')).toThrow(
+      'Option "ttl" for "cache" must be a finite number. Received 42.',
+    );
+  });
+
+  it('validates string options', () => {
+    expect(assertStringOption('preview', 'formatter', 'name')).toBe('preview');
+
+    expect(() => assertStringOption(12, 'formatter', 'name')).toThrow(
+      'Option "name" for "formatter" must be a string. Received 12.',
+    );
+  });
+
+  it('validates string array options and clones arrays', () => {
+    const input = ['json', 'yaml'];
+    const output = assertStringArrayOption(input, 'formatter', 'targets');
+
+    expect(output).toEqual(input);
+    expect(output).not.toBe(input);
+
+    expect(() => assertStringArrayOption('json', 'formatter', 'targets')).toThrow(
+      'Option "targets" for "formatter" must be an array of strings. Received "json".',
+    );
+
+    expect(() => assertStringArrayOption(['json', 1], 'formatter', 'targets')).toThrow(
+      'Option "targets" for "formatter" must be an array of strings. Received ["json",1].',
+    );
+  });
+});

--- a/packages/build/src/infrastructure/validation/dtif-schema-validator.spec.ts
+++ b/packages/build/src/infrastructure/validation/dtif-schema-validator.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DtifSchemaValidationAdapter } from './dtif-schema-validator.js';
+import type { SourceDiscoveryContext, SourceDocument } from '../../domain/ports/index.js';
+
+function createDocument(pointerPrefix = '/tokens'): SourceDocument {
+  return {
+    uri: 'file:///workspace/tokens.json',
+    pointerPrefix,
+    document: { token: { $type: 'color', $value: '#ffffff' } },
+  } as SourceDocument;
+}
+
+function createContext(): SourceDiscoveryContext {
+  return {
+    source: { id: 'tokens' },
+  } as SourceDiscoveryContext;
+}
+
+describe('DtifSchemaValidationAdapter', () => {
+  it('returns undefined when validation succeeds without schema errors', async () => {
+    const adapter = new DtifSchemaValidationAdapter();
+    const validate = vi.fn().mockReturnValue(true) as typeof vi.fn & {
+      errors?: unknown;
+    };
+    validate.errors = undefined;
+    (adapter as { validator: { validate: typeof validate } }).validator = { validate };
+
+    await expect(adapter.validate(createDocument(), createContext())).resolves.toBeUndefined();
+  });
+
+  it('maps validation errors with optional metadata and pointer segments', async () => {
+    const adapter = new DtifSchemaValidationAdapter();
+    const validate = vi.fn().mockReturnValue(false) as typeof vi.fn & {
+      errors?: unknown;
+    };
+    validate.errors = [
+      {
+        keyword: 'type',
+        instancePath: '#/token/$value',
+        schemaPath: '#/properties/token',
+        message: 'must be string',
+        params: { type: 'string' },
+      },
+      {
+        keyword: 'required',
+        instancePath: '',
+      },
+    ];
+    (adapter as { validator: { validate: typeof validate } }).validator = { validate };
+
+    const result = await adapter.validate(createDocument('/root'), createContext());
+
+    expect(result).toEqual([
+      {
+        kind: 'validation',
+        sourceId: 'tokens',
+        uri: 'file:///workspace/tokens.json',
+        pointerPrefix: '/root',
+        pointer: '#/root/token/$value',
+        instancePath: '#/token/$value',
+        keyword: 'type',
+        schemaPath: '#/properties/token',
+        message: 'must be string',
+        params: { type: 'string' },
+        severity: 'error',
+      },
+      {
+        kind: 'validation',
+        sourceId: 'tokens',
+        uri: 'file:///workspace/tokens.json',
+        pointerPrefix: '/root',
+        pointer: '/root',
+        instancePath: '#',
+        keyword: 'required',
+        severity: 'error',
+      },
+    ]);
+  });
+
+  it('normalises unknown or malformed ajv error fields', async () => {
+    const adapter = new DtifSchemaValidationAdapter();
+    const validate = vi.fn().mockReturnValue(true) as typeof vi.fn & {
+      errors?: unknown;
+    };
+    validate.errors = [
+      {
+        keyword: 123,
+        instancePath: undefined,
+        schemaPath: 42,
+        message: { text: 'invalid' },
+        params: 'bad-params',
+      },
+    ];
+    (adapter as { validator: { validate: typeof validate } }).validator = { validate };
+
+    const result = await adapter.validate(createDocument('/fallback'), createContext());
+
+    expect(result).toEqual([
+      {
+        kind: 'validation',
+        sourceId: 'tokens',
+        uri: 'file:///workspace/tokens.json',
+        pointerPrefix: '/fallback',
+        pointer: '/fallback',
+        instancePath: '#',
+        keyword: 'unknown',
+        severity: 'error',
+      },
+    ]);
+  });
+});

--- a/packages/build/src/transform/transform-groups.spec.ts
+++ b/packages/build/src/transform/transform-groups.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  TRANSFORM_GROUP_DEFAULT,
+  compareTransformGroups,
+  normaliseTransformGroupName,
+} from './transform-groups.js';
+
+describe('transform-groups', () => {
+  it('normalises missing, blank, and legacy group names', () => {
+    expect(normaliseTransformGroupName()).toBe(TRANSFORM_GROUP_DEFAULT);
+    expect(normaliseTransformGroupName('   ')).toBe(TRANSFORM_GROUP_DEFAULT);
+    expect(normaliseTransformGroupName('core')).toBe('web/base');
+    expect(normaliseTransformGroupName('android/material')).toBe('android/material');
+  });
+
+  it('orders known groups before unknown groups and sorts unknown groups lexicographically', () => {
+    const groups = ['z-unknown', 'ios/swiftui', 'a-unknown', 'android/material'];
+
+    const sorted = groups.toSorted(compareTransformGroups);
+
+    expect(sorted).toEqual(['ios/swiftui', 'android/material', 'a-unknown', 'z-unknown']);
+  });
+
+  it('returns zero when both groups resolve to the same canonical value', () => {
+    expect(compareTransformGroups('core', 'web/base')).toBe(0);
+  });
+});

--- a/packages/build/tests/watch-pipeline.spec.ts
+++ b/packages/build/tests/watch-pipeline.spec.ts
@@ -34,7 +34,7 @@ import { noopTelemetryTracer } from '@dtifx/core/telemetry';
 
 async function waitForCondition(
   predicate: () => boolean,
-  timeoutMs = 2000,
+  timeoutMs = 10_000,
   intervalMs = 10,
 ): Promise<void> {
   const timeoutAt = Date.now() + timeoutMs;

--- a/packages/build/vitest.config.ts
+++ b/packages/build/vitest.config.ts
@@ -17,8 +17,10 @@ export default mergeConfig(
     },
     test: {
       name: 'build',
+      silent: false,
       coverage: {
         reportsDirectory: path.resolve(__dirname, 'coverage'),
+        reportOnFailure: true,
       },
     },
   }),


### PR DESCRIPTION
### Motivation

- Reduce CI test flakiness in the build package by increasing polling timeouts for watch tests and improve failure diagnostics when tests fail. 

### Description

- Change the root test invocation to stream NX output by adding `--outputStyle=stream` to the `test` script in `package.json` so CI logs are produced live. 
- Increase the `waitForCondition` timeout from `2000` to `10_000` ms in `packages/build/tests/watch-pipeline.spec.ts` to reduce spurious timeouts under load. 
- Enable live test output and coverage-on-failure in the build package Vitest config by setting `silent: false` and `coverage.reportOnFailure: true` in `packages/build/vitest.config.ts`. 
- Add changeset files documenting the patch-level updates related to CI diagnostics and the increased watch pipeline timeout. 

### Testing

- Ran the monorepo test suite via the `test` script (`pnpm test` / `nx run-many -t test --all --outputStyle=stream`) and the build package tests, and they completed successfully. 
- Executed the build package Vitest run to ensure the `silent` and `coverage.reportOnFailure` options apply, and the run completed without errors. 
- Ran the updated watch pipeline spec and observed no immediate timeouts with the increased `waitForCondition` timeout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a18c66c56c8328925eaf4f1a3459b5)